### PR TITLE
Provision datastore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Specific
+.remote-sync.json
 station_list.csv
 config.ini
 writer_app.py

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ HiSPARC datastore
 =================
 
 This code takes care of receiving and storing the HiSPARC data on the main server.
+
+release (git tag): frome-pre2017: The version that is live on frome.

--- a/examples/datastore-config-server.py
+++ b/examples/datastore-config-server.py
@@ -1,0 +1,62 @@
+!/usr/local/bin/python
+""" Simple XML-RPC Server to run on the datastore server.
+    This daemon should be run on HiSPARC's datastore server.  It will
+    handle the cluster layouts and station passwords.  When an update is
+    necessary, it will reload the HTTP daemon.
+    The basis for this code was ripped from the python SimpleXMLRPCServer
+    library documentation and extended.
+"""
+from SimpleXMLRPCServer import SimpleXMLRPCServer
+from SimpleXMLRPCServer import SimpleXMLRPCRequestHandler
+import urllib2
+import hashlib
+import subprocess
+import os
+
+HASH = '/tmp/hash_datastore'
+DATASTORE_CFG = '/databases/frome/station_list.csv'
+CFG_URL = '{{ datastore_config_url }}'
+RELOAD_PATH = '/tmp/uwsgi-reload.me'
+
+def reload_datastore():
+    """Load datastore config and reload datastore, if necessary"""
+
+    datastore_cfg = urllib2.urlopen(CFG_URL).read()
+    new_hash = hashlib.sha1(datastore_cfg).hexdigest()
+
+    try:
+        with open(HASH, 'r') as file:
+            old_hash = file.readline()
+    except IOError:
+        old_hash = None
+
+    if new_hash == old_hash:
+        return True
+    else:
+        with open(DATASTORE_CFG, 'w') as file:
+            file.write(datastore_cfg)
+
+        # reload uWSGI
+        with open(RELOAD_PATH, 'a'):
+            os.utime(RELOAD_PATH, None)
+
+        with open(HASH, 'w') as file:
+            file.write(new_hash)
+
+    return True
+
+
+if __name__ == '__main__':
+    # Restrict to a particular path.
+    class RequestHandler(SimpleXMLRPCRequestHandler):
+        rpc_paths = ('/RPC2',)
+
+    # Create server
+    server = SimpleXMLRPCServer(('{{ datastore_host }}', {{ datastore_port }}),
+                                requestHandler=RequestHandler)
+    server.register_introspection_functions()
+
+    server.register_function(reload_datastore)
+
+    # Run the server's main loop
+    server.serve_forever()

--- a/migration/migrate_singles/README.md
+++ b/migration/migrate_singles/README.md
@@ -1,0 +1,54 @@
+HisparcSingle ('/singles' in the datastore ) colomns where `tables.UInt16Col`
+before HiSPARC/datastore@dec64079 (merged feb 12, 2017, after this migration).
+For stations without a slave (two detector stations) the slave columns where
+set to all zero, instead of all `-1` to represent 'missing sensor'.
+
+In this migration all datastore '/singles' tables where converted to the new
+format (`tables.Int32Col`: signed 32bit integers). The original tables are kept
+in the datastore files as '/singles_old'.
+
+After stopping the datastore writer, all affected datastore files were copied:
+
+tkooij@frome:
+```
+screen
+cp -var /databases/frome/2016/ /data/hisparc/backup_datastore_13feb2017/
+cp -var /databases/frome/2017/ /data/hisparc/backup_datastore_13feb2017/
+```
+
+conda env for frome with pytables-3.3.0 and up to date sapphire:
+tkooij@login:
+
+```
+conda create -n frome python=2.7 ipython numpy scipy pytables
+pip install hisparc-sapphire
+```
+
+Migrate:
+root@frome:
+```
+screen
+PATH=/data/hisparc/env/miniconda/bin:$PATH
+source activate frome
+python migrate_singles.py
+```
+
+Afterwards the writer was started.
+
+
+This resulting migration.log was commited in this folder.
+
+Errors from `migration.log` are shown below. Stations 91, 93 and 1102 are test
+stations. Station 1102 is staged to become an active station in the Utrecht
+cluster, but the affected data is test data.
+
+The error message states that there was no information about the station in
+the API. As a result, the station was treated as a 4 detector station and
+slave columns were not changed from 0 to -1. As station 1102 is a 4 detector
+station (with slave) this is not a problem.
+
+```
+2017-02-13 19:34:59,238 - ERROR - No information in HiSPARCNetwork() for sn 91
+2017-02-13 19:44:07,376 - ERROR - No information in HiSPARCNetwork() for sn 93
+2017-02-13 19:46:22,919 - ERROR - No information in HiSPARCNetwork() for sn 1102
+```

--- a/migration/migrate_singles/migrate_singles.py
+++ b/migration/migrate_singles/migrate_singles.py
@@ -1,0 +1,199 @@
+"""
+
+Migrate singles tables to new HisparcSingle format.
+
+HisparcSingle columns where `tables.UInt16Col` before
+HiSPARC/datastore@dec64079. Convert old tables to the new format.
+For a missing slave (two detector stations) the slave columns where set
+to all zero, instead of all `-1`. Set those columns to `-1`
+
+logging to logfile `migration.log`
+prints progressbars for searching and processing tables.
+
+"""
+from __future__ import print_function
+
+import glob
+import logging
+import re
+
+import numpy as np
+import tables
+from sapphire.utils import pbar
+from sapphire import HiSPARCNetwork
+
+
+DATASTORE_PATH = '/data/hisparc/tom/Datastore/frome/'
+# DATASTORE_PATH = '/databases/frome/'
+
+
+class MigrateSingles(object):
+    """Migrate singles to new table format
+       If the station has no slave *and* slave columns are all zero,
+       replace slave columns with `-1` to correctly represent missing slave.
+    """
+
+    class HisparcSingle(tables.IsDescription):
+        event_id = tables.UInt32Col(pos=0)
+        timestamp = tables.Time32Col(pos=1)
+        mas_ch1_low = tables.Int32Col(dflt=-1, pos=2)
+        mas_ch1_high = tables.Int32Col(dflt=-1, pos=3)
+        mas_ch2_low = tables.Int32Col(dflt=-1, pos=4)
+        mas_ch2_high = tables.Int32Col(dflt=-1, pos=5)
+        slv_ch1_low = tables.Int32Col(dflt=-1, pos=6)
+        slv_ch1_high = tables.Int32Col(dflt=-1, pos=7)
+        slv_ch2_low = tables.Int32Col(dflt=-1, pos=8)
+        slv_ch2_high = tables.Int32Col(dflt=-1, pos=9)
+
+    def __init__(self, data):
+        self.data = data
+        self.singles_dtype = \
+            tables.description.dtype_from_descr(self.HisparcSingle)
+        self.network = HiSPARCNetwork(force_stale=True)
+
+    def migrate_table(self, table_path):
+        """Migrate datatable to new format. Fix slave columns."""
+
+        logging.info('Migrating table: %s' % table_path)
+        group, table_name, sn = self._parse_path(table_path)
+
+        if table_name != 'singles':
+            logging.error('Table %s not `singles` skipping!' % table_path)
+            return None
+
+        tmp_table_name = '_t_%s' % table_name
+
+        try:
+            tmptable = self.data.create_table(group, tmp_table_name,
+                                              description=self.HisparcSingle)
+        except tables.NodeError:
+            logging.error('%s/_t_%s exists. Removing.' % (group, table_name))
+            self.data.remove_node(group, '_t_%s' % table_name)
+            tmptable = self.data.create_table(group, tmp_table_name,
+                                              description=self.HisparcSingle)
+
+        table = self.data.get_node(table_path)
+        data = table.read()
+        data = data.astype(self.singles_dtype)
+        if not self._has_slave(sn):
+            data = self._mark_slave_columns_as_missing(data)
+
+        tmptable.append(data)
+        tmptable.flush()
+        self.data.rename_node(table, 'singles_old')
+        self.data.rename_node(tmptable, 'singles')
+
+    def _parse_path(self, path):
+        """ '/cluster/s501/singles' ---> '/cluster/s501' 'singles', 501 """
+
+        group, table_name = tables.path.split_path(path)
+        re_number = re.compile('[0-9]+$')
+        numbers = [int(re_number.search(group).group())]
+        sn = numbers[-1]
+        return group, table_name, sn
+
+    def _has_slave(self, sn):
+        """Return True if station (sn) has slave (4 detectors)"""
+        try:
+            n_detectors = len(self.network.get_station(sn).detectors)
+        except AttributeError:
+            logging.error('No information in HiSPARCNetwork() for sn %d' % sn)
+            n_detectors = 4
+        return n_detectors == 4
+
+    def _mark_slave_columns_as_missing(self, table):
+        """Replace slave columns with `-1`"""
+
+        cols = ['slv_ch1_low', 'slv_ch2_low', 'slv_ch1_high', 'slv_ch2_high']
+        for col in cols:
+            if not np.all(table[col] == 0):
+                logging.error("Slave columns are not all zero. "
+                              "Leaving data untouched!")
+                return table
+
+        n = len(table)
+        for col in cols:
+            table[col] = n * [-1]
+
+        logging.debug("Set all slave columns to `-1`.")
+        return table
+
+
+def get_queue(datastore_path):
+    queue = {}
+    logging.info('Searching for unmigrated singles tables')
+
+    print('Looking for singles tables in datastore.')
+
+    # Singles tables were added in Feb, 2016.
+    for fn in pbar(glob.glob(datastore_path + '/201[6,7]/*/*h5')):
+
+        singles_tables = []
+        with tables.open_file(fn, 'r') as data:
+            for node in data.walk_nodes('/', 'Table'):
+                table_path = node._v_pathname
+                if '/singles' in table_path:
+                    if 'singles_old' in table_path:
+                        continue
+                    type_ = type(node.description.mas_ch1_low)
+                    if type_ == tables.UInt16Col:
+                        logging.debug('Found: %s' % table_path)
+                        singles_tables.append(table_path)
+                    elif type_ == tables.Int32Col:
+                        logging.debug('Skipping migrated: %s' % table_path)
+                        continue
+                    else:
+                        logging.error('%s in unknown format!' % table_path)
+
+        if singles_tables:
+            queue[fn] = singles_tables
+            logging.info('Found %d tables in %s' % (len(singles_tables), fn))
+
+    n = sum(len(v) for v in queue.itervalues())
+    logging.info('Found %d unmigrated tables '
+                 'in %d datastore files.' % (n, len(queue)))
+    return queue
+
+
+def migrate():
+    """
+    Find unmigrated tables in datastore
+    migrate tables
+    check datastore again for unmigrated tables
+    """
+
+    logging.info('******************')
+    logging.info('Starting migration')
+    logging.info('******************')
+
+    queue = get_queue(DATASTORE_PATH)
+    print('migrating:')
+    for path in pbar(queue.keys()):
+        logging.info('Migrating: %s' % path)
+        with tables.open_file(path, 'a') as data:
+            migration = MigrateSingles(data)
+            for table in queue[path]:
+                logging.debug('Processing table: %s' % table)
+                migration.migrate_table(table)
+
+    queue = get_queue(DATASTORE_PATH)
+    if queue:
+        logging.error('Found unprocessed tables after migration')
+        for path in queue.keys():
+            logging.error('Unprocessed tables in: %s' % path)
+            for table in queue[path]:
+                logging.error('%s' % table)
+    else:
+        logging.info('********************')
+        logging.info('Migration succesful!')
+        logging.info('********************')
+
+
+if __name__ == '__main__':
+    fmt = "%(asctime)s - %(levelname)s - %(message)s"
+    logging.basicConfig(filename='migration.log', level=logging.INFO,
+                        format=fmt)
+
+    logging.info('Datastore path: %s', DATASTORE_PATH)
+    migrate()
+    logging.info('Done.')

--- a/migration/migrate_singles/migration.log
+++ b/migration/migrate_singles/migration.log
@@ -1,0 +1,5010 @@
+2017-02-13 19:08:09,025 - INFO - Datastore path: /databases/frome/
+2017-02-13 19:08:09,025 - INFO - ******************
+2017-02-13 19:08:09,025 - INFO - Starting migration
+2017-02-13 19:08:09,025 - INFO - ******************
+2017-02-13 19:08:09,026 - INFO - Searching for unmigrated singles tables
+2017-02-13 19:10:45,930 - INFO - Found 1 tables in /databases/frome/2016/2/2016_2_26.h5
+2017-02-13 19:11:13,883 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_9.h5
+2017-02-13 19:11:17,179 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_10.h5
+2017-02-13 19:11:19,458 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_11.h5
+2017-02-13 19:11:21,400 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_12.h5
+2017-02-13 19:11:23,141 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_13.h5
+2017-02-13 19:11:25,381 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_14.h5
+2017-02-13 19:11:27,536 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_15.h5
+2017-02-13 19:11:29,486 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_16.h5
+2017-02-13 19:11:31,966 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_17.h5
+2017-02-13 19:11:35,032 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_18.h5
+2017-02-13 19:11:37,882 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_19.h5
+2017-02-13 19:11:40,883 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_20.h5
+2017-02-13 19:11:42,638 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_21.h5
+2017-02-13 19:11:45,280 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_22.h5
+2017-02-13 19:11:47,132 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_23.h5
+2017-02-13 19:11:49,382 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_24.h5
+2017-02-13 19:11:51,994 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_25.h5
+2017-02-13 19:11:54,703 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_26.h5
+2017-02-13 19:11:57,534 - INFO - Found 1 tables in /databases/frome/2016/3/2016_3_27.h5
+2017-02-13 19:12:01,289 - INFO - Found 3 tables in /databases/frome/2016/3/2016_3_29.h5
+2017-02-13 19:12:02,732 - INFO - Found 3 tables in /databases/frome/2016/3/2016_3_30.h5
+2017-02-13 19:12:04,753 - INFO - Found 3 tables in /databases/frome/2016/3/2016_3_31.h5
+2017-02-13 19:12:06,239 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_1.h5
+2017-02-13 19:12:07,699 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_2.h5
+2017-02-13 19:12:09,192 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_3.h5
+2017-02-13 19:12:10,769 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_4.h5
+2017-02-13 19:12:12,495 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_5.h5
+2017-02-13 19:12:14,395 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_6.h5
+2017-02-13 19:12:16,195 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_7.h5
+2017-02-13 19:12:17,949 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_8.h5
+2017-02-13 19:12:19,481 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_9.h5
+2017-02-13 19:12:21,289 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_10.h5
+2017-02-13 19:12:23,071 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_11.h5
+2017-02-13 19:12:24,832 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_12.h5
+2017-02-13 19:12:26,730 - INFO - Found 3 tables in /databases/frome/2016/4/2016_4_13.h5
+2017-02-13 19:12:29,464 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_14.h5
+2017-02-13 19:12:31,470 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_15.h5
+2017-02-13 19:12:33,397 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_16.h5
+2017-02-13 19:12:35,512 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_17.h5
+2017-02-13 19:12:37,524 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_18.h5
+2017-02-13 19:12:39,741 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_19.h5
+2017-02-13 19:12:41,755 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_20.h5
+2017-02-13 19:12:43,888 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_21.h5
+2017-02-13 19:12:46,243 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_22.h5
+2017-02-13 19:12:48,463 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_23.h5
+2017-02-13 19:12:50,563 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_24.h5
+2017-02-13 19:12:52,819 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_25.h5
+2017-02-13 19:12:55,028 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_26.h5
+2017-02-13 19:12:57,364 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_27.h5
+2017-02-13 19:12:59,309 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_28.h5
+2017-02-13 19:13:01,839 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_29.h5
+2017-02-13 19:13:04,101 - INFO - Found 4 tables in /databases/frome/2016/4/2016_4_30.h5
+2017-02-13 19:13:06,102 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_1.h5
+2017-02-13 19:13:07,917 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_2.h5
+2017-02-13 19:13:09,488 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_3.h5
+2017-02-13 19:13:11,189 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_4.h5
+2017-02-13 19:13:12,698 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_5.h5
+2017-02-13 19:13:14,653 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_6.h5
+2017-02-13 19:13:16,210 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_7.h5
+2017-02-13 19:13:17,596 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_8.h5
+2017-02-13 19:13:19,197 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_9.h5
+2017-02-13 19:13:20,832 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_10.h5
+2017-02-13 19:13:22,934 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_11.h5
+2017-02-13 19:13:24,667 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_12.h5
+2017-02-13 19:13:26,322 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_13.h5
+2017-02-13 19:13:28,228 - INFO - Found 3 tables in /databases/frome/2016/5/2016_5_14.h5
+2017-02-13 19:13:29,914 - INFO - Found 3 tables in /databases/frome/2016/5/2016_5_15.h5
+2017-02-13 19:13:31,644 - INFO - Found 3 tables in /databases/frome/2016/5/2016_5_16.h5
+2017-02-13 19:13:33,451 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_17.h5
+2017-02-13 19:13:35,198 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_18.h5
+2017-02-13 19:13:37,177 - INFO - Found 5 tables in /databases/frome/2016/5/2016_5_19.h5
+2017-02-13 19:13:38,829 - INFO - Found 5 tables in /databases/frome/2016/5/2016_5_20.h5
+2017-02-13 19:13:40,988 - INFO - Found 5 tables in /databases/frome/2016/5/2016_5_21.h5
+2017-02-13 19:13:42,611 - INFO - Found 5 tables in /databases/frome/2016/5/2016_5_22.h5
+2017-02-13 19:13:44,385 - INFO - Found 5 tables in /databases/frome/2016/5/2016_5_23.h5
+2017-02-13 19:13:46,088 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_24.h5
+2017-02-13 19:13:48,021 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_25.h5
+2017-02-13 19:13:50,526 - INFO - Found 5 tables in /databases/frome/2016/5/2016_5_26.h5
+2017-02-13 19:13:52,531 - INFO - Found 5 tables in /databases/frome/2016/5/2016_5_27.h5
+2017-02-13 19:13:54,412 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_28.h5
+2017-02-13 19:13:55,831 - INFO - Found 4 tables in /databases/frome/2016/5/2016_5_29.h5
+2017-02-13 19:13:58,047 - INFO - Found 5 tables in /databases/frome/2016/5/2016_5_30.h5
+2017-02-13 19:13:59,779 - INFO - Found 5 tables in /databases/frome/2016/5/2016_5_31.h5
+2017-02-13 19:14:01,438 - INFO - Found 5 tables in /databases/frome/2016/6/2016_6_1.h5
+2017-02-13 19:14:02,936 - INFO - Found 5 tables in /databases/frome/2016/6/2016_6_2.h5
+2017-02-13 19:14:04,953 - INFO - Found 5 tables in /databases/frome/2016/6/2016_6_3.h5
+2017-02-13 19:14:06,875 - INFO - Found 5 tables in /databases/frome/2016/6/2016_6_4.h5
+2017-02-13 19:14:08,604 - INFO - Found 5 tables in /databases/frome/2016/6/2016_6_5.h5
+2017-02-13 19:14:10,534 - INFO - Found 6 tables in /databases/frome/2016/6/2016_6_6.h5
+2017-02-13 19:14:12,490 - INFO - Found 6 tables in /databases/frome/2016/6/2016_6_7.h5
+2017-02-13 19:14:15,304 - INFO - Found 8 tables in /databases/frome/2016/6/2016_6_8.h5
+2017-02-13 19:14:18,024 - INFO - Found 7 tables in /databases/frome/2016/6/2016_6_9.h5
+2017-02-13 19:14:20,508 - INFO - Found 7 tables in /databases/frome/2016/6/2016_6_10.h5
+2017-02-13 19:14:22,343 - INFO - Found 6 tables in /databases/frome/2016/6/2016_6_11.h5
+2017-02-13 19:14:24,235 - INFO - Found 6 tables in /databases/frome/2016/6/2016_6_12.h5
+2017-02-13 19:14:26,872 - INFO - Found 7 tables in /databases/frome/2016/6/2016_6_13.h5
+2017-02-13 19:14:29,305 - INFO - Found 8 tables in /databases/frome/2016/6/2016_6_14.h5
+2017-02-13 19:14:31,737 - INFO - Found 8 tables in /databases/frome/2016/6/2016_6_15.h5
+2017-02-13 19:14:33,919 - INFO - Found 8 tables in /databases/frome/2016/6/2016_6_16.h5
+2017-02-13 19:14:36,227 - INFO - Found 9 tables in /databases/frome/2016/6/2016_6_17.h5
+2017-02-13 19:14:38,651 - INFO - Found 9 tables in /databases/frome/2016/6/2016_6_18.h5
+2017-02-13 19:14:41,121 - INFO - Found 9 tables in /databases/frome/2016/6/2016_6_19.h5
+2017-02-13 19:14:43,432 - INFO - Found 9 tables in /databases/frome/2016/6/2016_6_20.h5
+2017-02-13 19:14:46,438 - INFO - Found 9 tables in /databases/frome/2016/6/2016_6_21.h5
+2017-02-13 19:14:49,067 - INFO - Found 10 tables in /databases/frome/2016/6/2016_6_22.h5
+2017-02-13 19:14:51,423 - INFO - Found 10 tables in /databases/frome/2016/6/2016_6_23.h5
+2017-02-13 19:14:53,302 - INFO - Found 10 tables in /databases/frome/2016/6/2016_6_24.h5
+2017-02-13 19:14:55,171 - INFO - Found 9 tables in /databases/frome/2016/6/2016_6_25.h5
+2017-02-13 19:14:57,349 - INFO - Found 9 tables in /databases/frome/2016/6/2016_6_26.h5
+2017-02-13 19:14:59,655 - INFO - Found 10 tables in /databases/frome/2016/6/2016_6_27.h5
+2017-02-13 19:15:01,937 - INFO - Found 10 tables in /databases/frome/2016/6/2016_6_28.h5
+2017-02-13 19:15:03,679 - INFO - Found 9 tables in /databases/frome/2016/6/2016_6_29.h5
+2017-02-13 19:15:05,533 - INFO - Found 9 tables in /databases/frome/2016/6/2016_6_30.h5
+2017-02-13 19:15:07,560 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_1.h5
+2017-02-13 19:15:09,490 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_2.h5
+2017-02-13 19:15:11,629 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_3.h5
+2017-02-13 19:15:13,492 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_4.h5
+2017-02-13 19:15:15,953 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_5.h5
+2017-02-13 19:15:18,227 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_6.h5
+2017-02-13 19:15:20,274 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_7.h5
+2017-02-13 19:15:22,867 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_8.h5
+2017-02-13 19:15:24,870 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_9.h5
+2017-02-13 19:15:27,069 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_10.h5
+2017-02-13 19:15:29,525 - INFO - Found 9 tables in /databases/frome/2016/7/2016_7_11.h5
+2017-02-13 19:15:31,871 - INFO - Found 10 tables in /databases/frome/2016/7/2016_7_12.h5
+2017-02-13 19:15:34,505 - INFO - Found 12 tables in /databases/frome/2016/7/2016_7_13.h5
+2017-02-13 19:15:37,086 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_14.h5
+2017-02-13 19:15:39,960 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_15.h5
+2017-02-13 19:15:42,305 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_16.h5
+2017-02-13 19:15:44,854 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_17.h5
+2017-02-13 19:15:47,586 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_18.h5
+2017-02-13 19:15:49,996 - INFO - Found 12 tables in /databases/frome/2016/7/2016_7_19.h5
+2017-02-13 19:15:52,477 - INFO - Found 12 tables in /databases/frome/2016/7/2016_7_20.h5
+2017-02-13 19:15:54,711 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_21.h5
+2017-02-13 19:15:57,129 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_22.h5
+2017-02-13 19:15:59,422 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_23.h5
+2017-02-13 19:16:01,658 - INFO - Found 10 tables in /databases/frome/2016/7/2016_7_24.h5
+2017-02-13 19:16:03,976 - INFO - Found 10 tables in /databases/frome/2016/7/2016_7_25.h5
+2017-02-13 19:16:05,709 - INFO - Found 10 tables in /databases/frome/2016/7/2016_7_26.h5
+2017-02-13 19:16:07,652 - INFO - Found 10 tables in /databases/frome/2016/7/2016_7_27.h5
+2017-02-13 19:16:10,048 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_28.h5
+2017-02-13 19:16:12,208 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_29.h5
+2017-02-13 19:16:14,410 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_30.h5
+2017-02-13 19:16:16,244 - INFO - Found 11 tables in /databases/frome/2016/7/2016_7_31.h5
+2017-02-13 19:16:18,633 - INFO - Found 11 tables in /databases/frome/2016/8/2016_8_1.h5
+2017-02-13 19:16:20,794 - INFO - Found 11 tables in /databases/frome/2016/8/2016_8_2.h5
+2017-02-13 19:16:22,947 - INFO - Found 12 tables in /databases/frome/2016/8/2016_8_3.h5
+2017-02-13 19:16:25,410 - INFO - Found 12 tables in /databases/frome/2016/8/2016_8_4.h5
+2017-02-13 19:16:27,484 - INFO - Found 12 tables in /databases/frome/2016/8/2016_8_5.h5
+2017-02-13 19:16:30,323 - INFO - Found 12 tables in /databases/frome/2016/8/2016_8_6.h5
+2017-02-13 19:16:32,496 - INFO - Found 12 tables in /databases/frome/2016/8/2016_8_7.h5
+2017-02-13 19:16:34,695 - INFO - Found 12 tables in /databases/frome/2016/8/2016_8_8.h5
+2017-02-13 19:16:36,996 - INFO - Found 13 tables in /databases/frome/2016/8/2016_8_9.h5
+2017-02-13 19:16:39,773 - INFO - Found 13 tables in /databases/frome/2016/8/2016_8_10.h5
+2017-02-13 19:16:42,121 - INFO - Found 13 tables in /databases/frome/2016/8/2016_8_11.h5
+2017-02-13 19:16:44,382 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_12.h5
+2017-02-13 19:16:46,981 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_13.h5
+2017-02-13 19:16:49,732 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_14.h5
+2017-02-13 19:16:52,493 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_15.h5
+2017-02-13 19:16:55,324 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_16.h5
+2017-02-13 19:16:57,611 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_17.h5
+2017-02-13 19:17:00,102 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_18.h5
+2017-02-13 19:17:02,537 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_19.h5
+2017-02-13 19:17:04,940 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_20.h5
+2017-02-13 19:17:07,184 - INFO - Found 14 tables in /databases/frome/2016/8/2016_8_21.h5
+2017-02-13 19:17:09,627 - INFO - Found 15 tables in /databases/frome/2016/8/2016_8_22.h5
+2017-02-13 19:17:11,929 - INFO - Found 15 tables in /databases/frome/2016/8/2016_8_23.h5
+2017-02-13 19:17:14,349 - INFO - Found 15 tables in /databases/frome/2016/8/2016_8_24.h5
+2017-02-13 19:17:17,158 - INFO - Found 16 tables in /databases/frome/2016/8/2016_8_25.h5
+2017-02-13 19:17:19,803 - INFO - Found 16 tables in /databases/frome/2016/8/2016_8_26.h5
+2017-02-13 19:17:22,353 - INFO - Found 15 tables in /databases/frome/2016/8/2016_8_27.h5
+2017-02-13 19:17:25,080 - INFO - Found 15 tables in /databases/frome/2016/8/2016_8_28.h5
+2017-02-13 19:17:27,730 - INFO - Found 15 tables in /databases/frome/2016/8/2016_8_29.h5
+2017-02-13 19:17:30,390 - INFO - Found 15 tables in /databases/frome/2016/8/2016_8_30.h5
+2017-02-13 19:17:32,931 - INFO - Found 15 tables in /databases/frome/2016/8/2016_8_31.h5
+2017-02-13 19:17:35,573 - INFO - Found 15 tables in /databases/frome/2016/9/2016_9_1.h5
+2017-02-13 19:17:38,066 - INFO - Found 15 tables in /databases/frome/2016/9/2016_9_2.h5
+2017-02-13 19:17:40,500 - INFO - Found 15 tables in /databases/frome/2016/9/2016_9_3.h5
+2017-02-13 19:17:43,057 - INFO - Found 16 tables in /databases/frome/2016/9/2016_9_4.h5
+2017-02-13 19:17:45,544 - INFO - Found 16 tables in /databases/frome/2016/9/2016_9_5.h5
+2017-02-13 19:17:48,192 - INFO - Found 17 tables in /databases/frome/2016/9/2016_9_6.h5
+2017-02-13 19:17:51,307 - INFO - Found 16 tables in /databases/frome/2016/9/2016_9_7.h5
+2017-02-13 19:17:53,982 - INFO - Found 17 tables in /databases/frome/2016/9/2016_9_8.h5
+2017-02-13 19:17:56,632 - INFO - Found 16 tables in /databases/frome/2016/9/2016_9_9.h5
+2017-02-13 19:17:59,011 - INFO - Found 16 tables in /databases/frome/2016/9/2016_9_10.h5
+2017-02-13 19:18:01,620 - INFO - Found 16 tables in /databases/frome/2016/9/2016_9_11.h5
+2017-02-13 19:18:04,728 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_12.h5
+2017-02-13 19:18:07,719 - INFO - Found 19 tables in /databases/frome/2016/9/2016_9_13.h5
+2017-02-13 19:18:10,391 - INFO - Found 17 tables in /databases/frome/2016/9/2016_9_14.h5
+2017-02-13 19:18:13,214 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_15.h5
+2017-02-13 19:18:16,210 - INFO - Found 19 tables in /databases/frome/2016/9/2016_9_16.h5
+2017-02-13 19:18:18,993 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_17.h5
+2017-02-13 19:18:21,810 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_18.h5
+2017-02-13 19:18:25,079 - INFO - Found 20 tables in /databases/frome/2016/9/2016_9_19.h5
+2017-02-13 19:18:27,741 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_20.h5
+2017-02-13 19:18:30,925 - INFO - Found 19 tables in /databases/frome/2016/9/2016_9_21.h5
+2017-02-13 19:18:34,319 - INFO - Found 21 tables in /databases/frome/2016/9/2016_9_22.h5
+2017-02-13 19:18:37,553 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_23.h5
+2017-02-13 19:18:40,290 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_24.h5
+2017-02-13 19:18:43,310 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_25.h5
+2017-02-13 19:18:46,244 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_26.h5
+2017-02-13 19:18:49,105 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_27.h5
+2017-02-13 19:18:52,101 - INFO - Found 18 tables in /databases/frome/2016/9/2016_9_28.h5
+2017-02-13 19:18:55,313 - INFO - Found 19 tables in /databases/frome/2016/9/2016_9_29.h5
+2017-02-13 19:18:58,431 - INFO - Found 19 tables in /databases/frome/2016/9/2016_9_30.h5
+2017-02-13 19:19:01,310 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_1.h5
+2017-02-13 19:19:04,287 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_2.h5
+2017-02-13 19:19:07,207 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_3.h5
+2017-02-13 19:19:10,006 - INFO - Found 18 tables in /databases/frome/2016/10/2016_10_4.h5
+2017-02-13 19:19:13,078 - INFO - Found 18 tables in /databases/frome/2016/10/2016_10_5.h5
+2017-02-13 19:19:15,892 - INFO - Found 19 tables in /databases/frome/2016/10/2016_10_6.h5
+2017-02-13 19:19:18,614 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_7.h5
+2017-02-13 19:19:21,410 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_8.h5
+2017-02-13 19:19:24,126 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_9.h5
+2017-02-13 19:19:27,269 - INFO - Found 18 tables in /databases/frome/2016/10/2016_10_10.h5
+2017-02-13 19:19:30,258 - INFO - Found 18 tables in /databases/frome/2016/10/2016_10_11.h5
+2017-02-13 19:19:33,088 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_12.h5
+2017-02-13 19:19:36,125 - INFO - Found 19 tables in /databases/frome/2016/10/2016_10_13.h5
+2017-02-13 19:19:39,063 - INFO - Found 18 tables in /databases/frome/2016/10/2016_10_14.h5
+2017-02-13 19:19:41,862 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_15.h5
+2017-02-13 19:19:44,573 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_16.h5
+2017-02-13 19:19:47,549 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_17.h5
+2017-02-13 19:19:50,672 - INFO - Found 19 tables in /databases/frome/2016/10/2016_10_18.h5
+2017-02-13 19:19:53,521 - INFO - Found 18 tables in /databases/frome/2016/10/2016_10_19.h5
+2017-02-13 19:19:56,462 - INFO - Found 18 tables in /databases/frome/2016/10/2016_10_20.h5
+2017-02-13 19:19:59,375 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_21.h5
+2017-02-13 19:20:02,180 - INFO - Found 16 tables in /databases/frome/2016/10/2016_10_22.h5
+2017-02-13 19:20:04,795 - INFO - Found 16 tables in /databases/frome/2016/10/2016_10_23.h5
+2017-02-13 19:20:07,574 - INFO - Found 16 tables in /databases/frome/2016/10/2016_10_24.h5
+2017-02-13 19:20:10,243 - INFO - Found 16 tables in /databases/frome/2016/10/2016_10_25.h5
+2017-02-13 19:20:12,945 - INFO - Found 16 tables in /databases/frome/2016/10/2016_10_26.h5
+2017-02-13 19:20:15,621 - INFO - Found 16 tables in /databases/frome/2016/10/2016_10_27.h5
+2017-02-13 19:20:18,486 - INFO - Found 16 tables in /databases/frome/2016/10/2016_10_28.h5
+2017-02-13 19:20:21,434 - INFO - Found 16 tables in /databases/frome/2016/10/2016_10_29.h5
+2017-02-13 19:20:24,292 - INFO - Found 16 tables in /databases/frome/2016/10/2016_10_30.h5
+2017-02-13 19:20:27,379 - INFO - Found 17 tables in /databases/frome/2016/10/2016_10_31.h5
+2017-02-13 19:20:30,453 - INFO - Found 19 tables in /databases/frome/2016/11/2016_11_1.h5
+2017-02-13 19:20:33,371 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_2.h5
+2017-02-13 19:20:36,403 - INFO - Found 19 tables in /databases/frome/2016/11/2016_11_3.h5
+2017-02-13 19:20:39,325 - INFO - Found 18 tables in /databases/frome/2016/11/2016_11_4.h5
+2017-02-13 19:20:42,270 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_5.h5
+2017-02-13 19:20:44,837 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_6.h5
+2017-02-13 19:20:48,032 - INFO - Found 18 tables in /databases/frome/2016/11/2016_11_7.h5
+2017-02-13 19:20:50,838 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_8.h5
+2017-02-13 19:20:54,228 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_9.h5
+2017-02-13 19:20:57,003 - INFO - Found 16 tables in /databases/frome/2016/11/2016_11_10.h5
+2017-02-13 19:20:59,994 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_11.h5
+2017-02-13 19:21:03,067 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_12.h5
+2017-02-13 19:21:06,060 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_13.h5
+2017-02-13 19:21:08,816 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_14.h5
+2017-02-13 19:21:11,997 - INFO - Found 19 tables in /databases/frome/2016/11/2016_11_15.h5
+2017-02-13 19:21:14,637 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_16.h5
+2017-02-13 19:21:17,528 - INFO - Found 18 tables in /databases/frome/2016/11/2016_11_17.h5
+2017-02-13 19:21:20,870 - INFO - Found 19 tables in /databases/frome/2016/11/2016_11_18.h5
+2017-02-13 19:21:23,746 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_19.h5
+2017-02-13 19:21:26,400 - INFO - Found 17 tables in /databases/frome/2016/11/2016_11_20.h5
+2017-02-13 19:21:29,287 - INFO - Found 18 tables in /databases/frome/2016/11/2016_11_21.h5
+2017-02-13 19:21:32,267 - INFO - Found 18 tables in /databases/frome/2016/11/2016_11_22.h5
+2017-02-13 19:21:35,384 - INFO - Found 19 tables in /databases/frome/2016/11/2016_11_23.h5
+2017-02-13 19:21:38,792 - INFO - Found 20 tables in /databases/frome/2016/11/2016_11_24.h5
+2017-02-13 19:21:41,926 - INFO - Found 18 tables in /databases/frome/2016/11/2016_11_25.h5
+2017-02-13 19:21:45,065 - INFO - Found 18 tables in /databases/frome/2016/11/2016_11_26.h5
+2017-02-13 19:21:48,155 - INFO - Found 18 tables in /databases/frome/2016/11/2016_11_27.h5
+2017-02-13 19:21:51,222 - INFO - Found 19 tables in /databases/frome/2016/11/2016_11_28.h5
+2017-02-13 19:21:54,285 - INFO - Found 20 tables in /databases/frome/2016/11/2016_11_29.h5
+2017-02-13 19:21:57,530 - INFO - Found 18 tables in /databases/frome/2016/11/2016_11_30.h5
+2017-02-13 19:22:00,678 - INFO - Found 19 tables in /databases/frome/2016/12/2016_12_1.h5
+2017-02-13 19:22:03,832 - INFO - Found 19 tables in /databases/frome/2016/12/2016_12_2.h5
+2017-02-13 19:22:06,862 - INFO - Found 18 tables in /databases/frome/2016/12/2016_12_3.h5
+2017-02-13 19:22:09,743 - INFO - Found 18 tables in /databases/frome/2016/12/2016_12_4.h5
+2017-02-13 19:22:13,047 - INFO - Found 19 tables in /databases/frome/2016/12/2016_12_5.h5
+2017-02-13 19:22:16,301 - INFO - Found 19 tables in /databases/frome/2016/12/2016_12_6.h5
+2017-02-13 19:22:19,219 - INFO - Found 19 tables in /databases/frome/2016/12/2016_12_7.h5
+2017-02-13 19:22:22,623 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_8.h5
+2017-02-13 19:22:26,213 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_9.h5
+2017-02-13 19:22:29,712 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_10.h5
+2017-02-13 19:22:33,108 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_11.h5
+2017-02-13 19:22:36,537 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_12.h5
+2017-02-13 19:22:40,155 - INFO - Found 21 tables in /databases/frome/2016/12/2016_12_13.h5
+2017-02-13 19:22:43,872 - INFO - Found 22 tables in /databases/frome/2016/12/2016_12_14.h5
+2017-02-13 19:22:47,877 - INFO - Found 22 tables in /databases/frome/2016/12/2016_12_15.h5
+2017-02-13 19:22:51,441 - INFO - Found 22 tables in /databases/frome/2016/12/2016_12_16.h5
+2017-02-13 19:22:54,867 - INFO - Found 21 tables in /databases/frome/2016/12/2016_12_17.h5
+2017-02-13 19:22:58,309 - INFO - Found 21 tables in /databases/frome/2016/12/2016_12_18.h5
+2017-02-13 19:23:01,850 - INFO - Found 21 tables in /databases/frome/2016/12/2016_12_19.h5
+2017-02-13 19:23:05,356 - INFO - Found 22 tables in /databases/frome/2016/12/2016_12_20.h5
+2017-02-13 19:23:08,531 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_21.h5
+2017-02-13 19:23:11,511 - INFO - Found 21 tables in /databases/frome/2016/12/2016_12_22.h5
+2017-02-13 19:23:14,721 - INFO - Found 21 tables in /databases/frome/2016/12/2016_12_23.h5
+2017-02-13 19:23:17,789 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_24.h5
+2017-02-13 19:23:20,538 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_25.h5
+2017-02-13 19:23:23,524 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_26.h5
+2017-02-13 19:23:26,349 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_27.h5
+2017-02-13 19:23:29,543 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_28.h5
+2017-02-13 19:23:32,438 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_29.h5
+2017-02-13 19:23:34,130 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_30.h5
+2017-02-13 19:23:35,865 - INFO - Found 20 tables in /databases/frome/2016/12/2016_12_31.h5
+2017-02-13 19:23:38,835 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_1.h5
+2017-02-13 19:23:41,518 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_2.h5
+2017-02-13 19:23:44,417 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_3.h5
+2017-02-13 19:23:47,571 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_4.h5
+2017-02-13 19:23:50,492 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_5.h5
+2017-02-13 19:23:53,511 - INFO - Found 19 tables in /databases/frome/2017/1/2017_1_6.h5
+2017-02-13 19:23:56,365 - INFO - Found 19 tables in /databases/frome/2017/1/2017_1_7.h5
+2017-02-13 19:23:59,329 - INFO - Found 19 tables in /databases/frome/2017/1/2017_1_8.h5
+2017-02-13 19:24:02,440 - INFO - Found 19 tables in /databases/frome/2017/1/2017_1_9.h5
+2017-02-13 19:24:05,588 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_10.h5
+2017-02-13 19:24:08,719 - INFO - Found 19 tables in /databases/frome/2017/1/2017_1_11.h5
+2017-02-13 19:24:11,996 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_12.h5
+2017-02-13 19:24:15,275 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_13.h5
+2017-02-13 19:24:18,449 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_14.h5
+2017-02-13 19:24:21,638 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_15.h5
+2017-02-13 19:24:24,744 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_16.h5
+2017-02-13 19:24:28,265 - INFO - Found 21 tables in /databases/frome/2017/1/2017_1_17.h5
+2017-02-13 19:24:31,435 - INFO - Found 21 tables in /databases/frome/2017/1/2017_1_18.h5
+2017-02-13 19:24:34,494 - INFO - Found 19 tables in /databases/frome/2017/1/2017_1_19.h5
+2017-02-13 19:24:37,418 - INFO - Found 18 tables in /databases/frome/2017/1/2017_1_20.h5
+2017-02-13 19:24:40,360 - INFO - Found 18 tables in /databases/frome/2017/1/2017_1_21.h5
+2017-02-13 19:24:43,371 - INFO - Found 18 tables in /databases/frome/2017/1/2017_1_22.h5
+2017-02-13 19:24:46,639 - INFO - Found 21 tables in /databases/frome/2017/1/2017_1_23.h5
+2017-02-13 19:24:49,629 - INFO - Found 18 tables in /databases/frome/2017/1/2017_1_24.h5
+2017-02-13 19:24:52,916 - INFO - Found 20 tables in /databases/frome/2017/1/2017_1_25.h5
+2017-02-13 19:24:56,072 - INFO - Found 19 tables in /databases/frome/2017/1/2017_1_26.h5
+2017-02-13 19:24:59,130 - INFO - Found 18 tables in /databases/frome/2017/1/2017_1_27.h5
+2017-02-13 19:25:02,303 - INFO - Found 17 tables in /databases/frome/2017/1/2017_1_28.h5
+2017-02-13 19:25:05,293 - INFO - Found 17 tables in /databases/frome/2017/1/2017_1_29.h5
+2017-02-13 19:25:08,392 - INFO - Found 19 tables in /databases/frome/2017/1/2017_1_30.h5
+2017-02-13 19:25:11,679 - INFO - Found 19 tables in /databases/frome/2017/1/2017_1_31.h5
+2017-02-13 19:25:14,719 - INFO - Found 18 tables in /databases/frome/2017/2/2017_2_1.h5
+2017-02-13 19:25:17,756 - INFO - Found 19 tables in /databases/frome/2017/2/2017_2_2.h5
+2017-02-13 19:25:20,815 - INFO - Found 19 tables in /databases/frome/2017/2/2017_2_3.h5
+2017-02-13 19:25:23,864 - INFO - Found 19 tables in /databases/frome/2017/2/2017_2_4.h5
+2017-02-13 19:25:26,740 - INFO - Found 18 tables in /databases/frome/2017/2/2017_2_5.h5
+2017-02-13 19:25:30,220 - INFO - Found 20 tables in /databases/frome/2017/2/2017_2_6.h5
+2017-02-13 19:25:33,378 - INFO - Found 19 tables in /databases/frome/2017/2/2017_2_7.h5
+2017-02-13 19:25:36,562 - INFO - Found 18 tables in /databases/frome/2017/2/2017_2_8.h5
+2017-02-13 19:25:39,566 - INFO - Found 18 tables in /databases/frome/2017/2/2017_2_9.h5
+2017-02-13 19:25:42,679 - INFO - Found 18 tables in /databases/frome/2017/2/2017_2_10.h5
+2017-02-13 19:25:45,387 - INFO - Found 18 tables in /databases/frome/2017/2/2017_2_11.h5
+2017-02-13 19:25:48,202 - INFO - Found 18 tables in /databases/frome/2017/2/2017_2_12.h5
+2017-02-13 19:25:51,280 - INFO - Found 17 tables in /databases/frome/2017/2/2017_2_13.h5
+2017-02-13 19:25:51,280 - INFO - Found 4296 unmigrated tables in 342 datastore files.
+2017-02-13 19:25:51,284 - INFO - Migrating: /databases/frome/2016/3/2016_3_23.h5
+2017-02-13 19:25:52,978 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:25:54,401 - INFO - Migrating: /databases/frome/2016/8/2016_8_27.h5
+2017-02-13 19:25:54,850 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:25:57,851 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:26:00,503 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:26:01,329 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:26:04,211 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:26:06,785 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:26:09,359 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:26:11,958 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:26:14,619 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:26:17,188 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:26:19,865 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:26:22,396 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:26:24,815 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:26:27,399 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:26:30,086 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:26:33,181 - INFO - Migrating: /databases/frome/2016/5/2016_5_10.h5
+2017-02-13 19:26:33,644 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:26:34,464 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:26:36,511 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:26:38,743 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:26:40,954 - INFO - Migrating: /databases/frome/2016/8/2016_8_21.h5
+2017-02-13 19:26:41,390 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:26:44,290 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:26:46,717 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:26:49,049 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:26:51,296 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:26:52,850 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:26:55,168 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:26:57,508 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:26:59,810 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:27:01,925 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:27:04,314 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:27:06,405 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:27:08,743 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:27:10,879 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:27:13,667 - INFO - Migrating: /databases/frome/2016/7/2016_7_20.h5
+2017-02-13 19:27:14,129 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:27:16,947 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:27:17,170 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:27:19,737 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:27:22,428 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:27:24,873 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:27:27,636 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:27:29,991 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:27:32,258 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:27:34,534 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:27:37,044 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:27:39,278 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:27:41,919 - INFO - Migrating: /databases/frome/2016/4/2016_4_20.h5
+2017-02-13 19:27:42,356 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:27:45,205 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:27:47,951 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:27:50,305 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:27:53,280 - INFO - Migrating: /databases/frome/2016/10/2016_10_8.h5
+2017-02-13 19:27:53,695 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:27:56,401 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:27:59,211 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:28:00,194 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:28:02,746 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:28:05,292 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:28:07,806 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:28:10,272 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:28:12,763 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:28:15,208 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:28:17,472 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:28:19,900 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:28:22,296 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:28:24,947 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:28:26,029 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:28:28,831 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:28:31,426 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:28:32,684 - INFO - Migrating: /databases/frome/2016/3/2016_3_20.h5
+2017-02-13 19:28:33,124 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:28:35,257 - INFO - Migrating: /databases/frome/2016/7/2016_7_12.h5
+2017-02-13 19:28:35,671 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:28:38,566 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:28:41,110 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:28:41,887 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:28:43,621 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:28:45,761 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:28:48,003 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:28:49,349 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:28:51,558 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:28:53,858 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:28:56,519 - INFO - Migrating: /databases/frome/2016/6/2016_6_15.h5
+2017-02-13 19:28:56,934 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:28:59,574 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:29:01,961 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:29:03,848 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:29:06,297 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:29:06,614 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:29:08,789 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:29:10,779 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:29:13,197 - INFO - Migrating: /databases/frome/2016/7/2016_7_1.h5
+2017-02-13 19:29:13,611 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:29:15,959 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:29:17,905 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:29:18,645 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:29:20,299 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:29:21,820 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:29:23,761 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:29:25,363 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:29:26,986 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:29:28,838 - INFO - Migrating: /databases/frome/2017/1/2017_1_18.h5
+2017-02-13 19:29:29,294 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:29:31,514 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:29:31,557 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:29:33,825 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:29:35,766 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:29:37,670 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:29:39,762 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:29:41,600 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:29:43,500 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:29:45,348 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 19:29:45,872 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:29:46,791 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:29:48,633 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:29:50,564 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:29:52,593 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:29:53,224 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 19:29:54,962 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:29:56,955 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:29:58,833 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:30:00,725 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:30:03,445 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:30:05,523 - INFO - Migrating: /databases/frome/2016/12/2016_12_3.h5
+2017-02-13 19:30:05,967 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:30:08,658 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:30:11,298 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:30:12,202 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:30:14,528 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:30:17,032 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:30:19,328 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:30:21,629 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:30:24,056 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:30:26,297 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:30:28,563 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:30:30,968 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:30:33,192 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:30:35,517 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:30:37,699 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:30:39,972 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:30:42,300 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:30:45,259 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:30:48,210 - INFO - Migrating: /databases/frome/2016/7/2016_7_3.h5
+2017-02-13 19:30:48,624 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:30:50,958 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:30:53,208 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:30:53,968 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:30:56,036 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:30:58,006 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:30:59,721 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:31:01,495 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:31:03,429 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:31:05,423 - INFO - Migrating: /databases/frome/2016/6/2016_6_2.h5
+2017-02-13 19:31:05,841 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:31:07,066 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:31:07,764 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:31:10,333 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:31:12,672 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:31:15,196 - INFO - Migrating: /databases/frome/2016/12/2016_12_17.h5
+2017-02-13 19:31:15,636 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:31:19,068 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:31:20,767 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:31:24,056 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:31:27,125 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:31:30,229 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:31:33,237 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:31:36,329 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:31:39,328 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:31:41,722 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:31:44,750 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 19:31:45,352 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:31:48,511 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:31:51,712 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:31:55,373 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:31:58,385 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:32:01,394 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:32:01,888 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:32:04,876 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:32:07,935 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:32:11,182 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:32:14,337 - INFO - Migrating: /databases/frome/2016/6/2016_6_3.h5
+2017-02-13 19:32:14,755 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:32:17,567 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:32:18,376 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:32:20,899 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:32:23,345 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:32:25,762 - INFO - Migrating: /databases/frome/2016/10/2016_10_17.h5
+2017-02-13 19:32:26,200 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:32:28,809 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:32:31,200 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:32:32,812 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:32:35,205 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:32:37,620 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:32:39,883 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:32:42,266 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:32:43,441 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:32:45,577 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:32:47,948 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:32:50,272 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:32:52,798 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:32:55,250 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:32:57,820 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:33:00,208 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:33:02,433 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:33:05,492 - INFO - Migrating: /databases/frome/2016/12/2016_12_19.h5
+2017-02-13 19:33:05,907 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:33:09,309 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:33:10,817 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:33:14,097 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:33:17,171 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:33:20,127 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:33:23,261 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:33:26,352 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:33:29,411 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:33:32,376 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:33:35,564 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 19:33:36,233 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:33:39,357 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:33:42,591 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:33:45,962 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:33:48,855 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:33:51,904 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:33:52,341 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:33:55,439 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:33:58,554 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:34:01,389 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:34:04,754 - INFO - Migrating: /databases/frome/2016/9/2016_9_25.h5
+2017-02-13 19:34:05,194 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:34:08,610 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:34:11,986 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:34:14,979 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:34:17,962 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:34:20,915 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:34:23,999 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:34:26,755 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:34:29,683 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:34:32,531 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:34:35,383 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:34:38,297 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:34:41,039 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:34:44,365 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:34:47,387 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:34:50,265 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:34:53,393 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:34:56,343 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_91/singles
+2017-02-13 19:34:59,238 - ERROR - No information in HiSPARCNetwork() for sn 91
+2017-02-13 19:34:59,454 - INFO - Migrating: /databases/frome/2017/2/2017_2_6.h5
+2017-02-13 19:34:59,910 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:35:02,856 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:35:05,482 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:35:08,042 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:35:10,563 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:35:13,034 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:35:15,670 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:35:18,210 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:35:20,723 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 19:35:23,301 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 19:35:23,922 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:35:26,374 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:35:28,676 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:35:31,090 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:35:33,580 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 19:35:36,086 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:35:39,104 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:35:41,631 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:35:44,176 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 19:35:44,243 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:35:45,528 - INFO - Migrating: /databases/frome/2016/5/2016_5_25.h5
+2017-02-13 19:35:45,966 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:35:49,226 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:35:52,241 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:35:55,303 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:35:58,169 - INFO - Migrating: /databases/frome/2016/10/2016_10_1.h5
+2017-02-13 19:35:58,583 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:36:01,855 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:36:05,075 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:36:07,993 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:36:10,759 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:36:13,519 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:36:16,337 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:36:19,006 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:36:21,806 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:36:24,490 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:36:27,236 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:36:29,969 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:36:32,613 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:36:35,724 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:36:38,232 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:36:41,061 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:36:43,645 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:36:46,518 - INFO - Migrating: /databases/frome/2016/8/2016_8_10.h5
+2017-02-13 19:36:46,957 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:36:49,197 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:36:51,352 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:36:53,312 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:36:55,144 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:36:56,935 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:36:58,781 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:37:00,573 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:37:02,349 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:37:04,316 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:37:06,154 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:37:08,006 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:37:09,707 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:37:11,874 - INFO - Migrating: /databases/frome/2016/9/2016_9_6.h5
+2017-02-13 19:37:12,288 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:37:14,755 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:37:14,785 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:37:17,091 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:37:17,776 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:37:19,818 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:37:21,945 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:37:23,941 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:37:25,966 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:37:28,167 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:37:30,088 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:37:32,057 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:37:33,979 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:37:36,111 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:37:37,873 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:37:39,758 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:37:41,767 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:37:44,014 - INFO - Migrating: /databases/frome/2016/5/2016_5_26.h5
+2017-02-13 19:37:44,428 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:37:46,948 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:37:47,273 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:37:49,534 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:37:52,014 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:37:54,548 - INFO - Migrating: /databases/frome/2016/9/2016_9_22.h5
+2017-02-13 19:37:54,987 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:37:58,316 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:37:58,388 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:38:01,583 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:38:04,633 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:38:07,476 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:38:10,285 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:38:13,230 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:38:16,071 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:38:19,163 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:38:21,943 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:38:24,672 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:38:27,469 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 19:38:30,235 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_25/singles
+2017-02-13 19:38:30,247 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:38:33,558 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:38:34,975 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:38:38,058 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:38:41,097 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:38:43,988 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:38:47,124 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_91/singles
+2017-02-13 19:38:47,438 - ERROR - No information in HiSPARCNetwork() for sn 91
+2017-02-13 19:38:47,498 - INFO - Migrating: /databases/frome/2016/3/2016_3_15.h5
+2017-02-13 19:38:47,912 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:38:49,262 - INFO - Migrating: /databases/frome/2016/7/2016_7_30.h5
+2017-02-13 19:38:49,675 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:38:52,576 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:38:55,297 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:38:58,017 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:39:00,569 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:39:01,125 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:39:03,437 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:39:06,017 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:39:08,266 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:39:10,484 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:39:12,770 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:39:15,483 - INFO - Migrating: /databases/frome/2016/3/2016_3_24.h5
+2017-02-13 19:39:15,968 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:39:17,638 - INFO - Migrating: /databases/frome/2016/8/2016_8_24.h5
+2017-02-13 19:39:18,053 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:39:20,989 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:39:23,897 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:39:26,455 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:39:28,880 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:39:30,960 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:39:33,037 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:39:35,435 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:39:37,944 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:39:40,343 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:39:42,628 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:39:44,802 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:39:47,145 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:39:49,408 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:39:51,874 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:39:54,845 - INFO - Migrating: /databases/frome/2017/2/2017_2_12.h5
+2017-02-13 19:39:55,260 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:39:58,154 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:40:00,912 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:40:03,456 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:40:06,148 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:40:08,551 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:40:11,161 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:40:13,513 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:40:15,628 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 19:40:18,139 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 19:40:20,665 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:40:23,176 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:40:25,619 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:40:28,260 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:40:30,953 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 19:40:34,009 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:40:36,514 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:40:39,098 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:40:41,635 - INFO - Migrating: /databases/frome/2016/4/2016_4_3.h5
+2017-02-13 19:40:42,077 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:40:44,367 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:40:46,807 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:40:49,195 - INFO - Migrating: /databases/frome/2016/11/2016_11_17.h5
+2017-02-13 19:40:49,611 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:40:52,226 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:40:52,238 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:40:54,880 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:40:56,316 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:40:58,731 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:41:01,128 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:41:03,423 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:41:05,842 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:41:08,246 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:41:10,629 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:41:13,006 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:41:15,384 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:41:17,661 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:41:19,934 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:41:22,350 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:41:25,081 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:41:27,490 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:41:30,262 - INFO - Migrating: /databases/frome/2016/6/2016_6_9.h5
+2017-02-13 19:41:30,677 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:41:32,986 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:41:33,586 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:41:33,964 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:41:34,156 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:41:36,436 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:41:38,776 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_521/singles
+2017-02-13 19:41:41,029 - INFO - Migrating: /databases/frome/2016/5/2016_5_7.h5
+2017-02-13 19:41:41,443 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:41:43,440 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:41:45,421 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:41:47,287 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:41:49,218 - INFO - Migrating: /databases/frome/2017/2/2017_2_7.h5
+2017-02-13 19:41:49,659 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:41:52,176 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:41:55,037 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:41:57,293 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:41:59,561 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:42:01,702 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:42:03,777 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:42:06,349 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:42:08,451 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 19:42:10,843 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 19:42:12,087 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:42:14,167 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:42:16,424 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:42:18,440 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:42:20,507 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 19:42:22,802 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:42:25,662 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:42:25,886 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:42:28,176 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:42:30,151 - INFO - Migrating: /databases/frome/2016/9/2016_9_18.h5
+2017-02-13 19:42:30,568 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:42:33,134 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:42:35,678 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:42:38,152 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:42:40,576 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:42:42,916 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:42:45,196 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:42:47,563 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:42:50,057 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:42:52,340 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:42:54,655 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:42:56,929 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 19:42:57,893 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:43:00,253 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:43:02,858 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:43:05,309 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:43:07,552 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:43:10,393 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:43:12,829 - INFO - Migrating: /databases/frome/2016/5/2016_5_1.h5
+2017-02-13 19:43:13,267 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:43:17,729 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:43:20,710 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:43:23,296 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:43:26,295 - INFO - Migrating: /databases/frome/2016/6/2016_6_17.h5
+2017-02-13 19:43:26,707 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:43:29,425 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:43:32,093 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:43:34,450 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:43:36,719 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:43:38,982 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:43:41,139 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:43:43,232 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:43:45,037 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:43:46,183 - INFO - Migrating: /databases/frome/2016/7/2016_7_13.h5
+2017-02-13 19:43:46,598 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:43:49,301 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:43:51,441 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:43:52,411 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:43:54,657 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:43:56,864 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:43:59,038 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:44:01,045 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:44:01,072 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:44:03,138 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:44:05,325 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:44:07,290 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_93/singles
+2017-02-13 19:44:07,376 - ERROR - No information in HiSPARCNetwork() for sn 93
+2017-02-13 19:44:07,710 - INFO - Migrating: /databases/frome/2016/6/2016_6_4.h5
+2017-02-13 19:44:08,125 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:44:10,952 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:44:11,578 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:44:13,718 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:44:16,260 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:44:18,511 - INFO - Migrating: /databases/frome/2016/7/2016_7_6.h5
+2017-02-13 19:44:18,951 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:44:20,961 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:44:22,736 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:44:23,267 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:44:25,307 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:44:26,931 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:44:28,601 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:44:30,072 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:44:31,601 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:44:33,403 - INFO - Migrating: /databases/frome/2016/4/2016_4_22.h5
+2017-02-13 19:44:33,819 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:44:36,588 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:44:39,027 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:44:40,896 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:44:43,085 - INFO - Migrating: /databases/frome/2016/11/2016_11_13.h5
+2017-02-13 19:44:43,500 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:44:46,790 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:44:50,381 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:44:53,385 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:44:56,220 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:44:59,015 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:45:02,548 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:45:05,558 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:45:08,459 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:45:11,881 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:45:14,532 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:45:17,139 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:45:20,348 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:45:23,297 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:45:26,236 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:45:28,868 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 19:45:28,882 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:45:31,845 - INFO - Migrating: /databases/frome/2016/4/2016_4_15.h5
+2017-02-13 19:45:32,287 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:45:33,998 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:45:36,263 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:45:38,775 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:45:41,123 - INFO - Migrating: /databases/frome/2016/10/2016_10_27.h5
+2017-02-13 19:45:41,538 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:45:44,345 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:45:47,017 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:45:48,034 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:45:50,499 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:45:53,581 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:45:56,138 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:45:58,563 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:46:01,109 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:46:03,639 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:46:06,184 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:46:08,611 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:46:11,035 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:46:13,725 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:46:16,159 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:46:19,147 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:46:21,730 - INFO - Migrating: /databases/frome/2016/5/2016_5_23.h5
+2017-02-13 19:46:22,144 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1102/singles
+2017-02-13 19:46:22,919 - ERROR - No information in HiSPARCNetwork() for sn 1102
+2017-02-13 19:46:22,932 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:46:24,511 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:46:26,118 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:46:27,640 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:46:29,906 - INFO - Migrating: /databases/frome/2016/10/2016_10_3.h5
+2017-02-13 19:46:30,320 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:46:33,103 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:46:35,694 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:46:38,384 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:46:40,831 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:46:43,262 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:46:45,755 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:46:48,144 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:46:50,677 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:46:53,490 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:46:55,948 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:46:58,455 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:47:01,231 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:47:03,851 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:47:06,474 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:47:10,047 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:47:12,633 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:47:15,455 - INFO - Migrating: /databases/frome/2016/8/2016_8_18.h5
+2017-02-13 19:47:15,898 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:47:19,051 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:47:21,629 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:47:23,843 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:47:25,970 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:47:28,006 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:47:29,993 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:47:31,947 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:47:34,028 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:47:35,951 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:47:37,964 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:47:39,988 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:47:41,956 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:47:44,098 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:47:46,617 - INFO - Migrating: /databases/frome/2016/10/2016_10_21.h5
+2017-02-13 19:47:47,032 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:47:49,990 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:47:52,318 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:47:53,536 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:47:55,289 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:47:57,040 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:47:58,868 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:48:00,567 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:48:02,252 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:48:03,327 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:48:05,155 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:48:06,890 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:48:08,622 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:48:10,293 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:48:12,085 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:48:13,757 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:48:15,431 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:48:17,711 - INFO - Migrating: /databases/frome/2016/5/2016_5_21.h5
+2017-02-13 19:48:18,152 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1102/singles
+2017-02-13 19:48:20,663 - ERROR - No information in HiSPARCNetwork() for sn 1102
+2017-02-13 19:48:20,674 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:48:23,409 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:48:25,184 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:48:27,025 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:48:29,020 - INFO - Migrating: /databases/frome/2016/9/2016_9_5.h5
+2017-02-13 19:48:29,434 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:48:31,195 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:48:32,677 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:48:33,265 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:48:34,768 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:48:36,293 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:48:38,341 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:48:39,747 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:48:41,246 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:48:42,649 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:48:44,123 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:48:45,462 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:48:46,897 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:48:48,225 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:48:49,681 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:48:51,161 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:48:53,106 - INFO - Migrating: /databases/frome/2016/7/2016_7_28.h5
+2017-02-13 19:48:53,521 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:48:56,004 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:48:58,649 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:49:00,424 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:49:02,265 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:49:04,029 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:49:05,889 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:49:07,634 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:49:08,686 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:49:10,399 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:49:12,143 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:49:14,449 - INFO - Migrating: /databases/frome/2016/9/2016_9_20.h5
+2017-02-13 19:49:14,865 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:49:18,555 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:49:21,034 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:49:23,786 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:49:26,188 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:49:28,376 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:49:30,635 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:49:32,907 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:49:35,009 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:49:37,131 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:49:39,316 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:49:41,555 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:49:43,755 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:49:46,007 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:49:48,281 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:49:50,586 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:49:52,767 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:49:56,000 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_91/singles
+2017-02-13 19:49:56,140 - ERROR - No information in HiSPARCNetwork() for sn 91
+2017-02-13 19:49:56,190 - INFO - Migrating: /databases/frome/2016/4/2016_4_10.h5
+2017-02-13 19:49:56,629 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:49:58,430 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:50:00,544 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:50:02,509 - INFO - Migrating: /databases/frome/2016/10/2016_10_11.h5
+2017-02-13 19:50:02,924 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:50:05,429 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:50:05,441 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:50:07,943 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:50:08,766 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:50:11,054 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:50:13,458 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:50:15,819 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:50:18,149 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:50:20,488 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:50:22,714 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:50:24,990 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:50:27,364 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:50:29,753 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:50:32,099 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:50:33,267 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:50:35,610 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:50:38,378 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:50:40,929 - INFO - Migrating: /databases/frome/2016/10/2016_10_28.h5
+2017-02-13 19:50:41,344 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:50:44,482 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:50:47,845 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:50:48,994 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:50:52,167 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:50:55,070 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:50:58,084 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:51:00,830 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:51:03,827 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:51:06,834 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:51:09,741 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:51:12,551 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:51:15,591 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:51:18,990 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:51:22,108 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:51:25,212 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:51:28,248 - INFO - Migrating: /databases/frome/2016/5/2016_5_16.h5
+2017-02-13 19:51:28,729 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:51:30,853 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:51:32,649 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:51:34,497 - INFO - Migrating: /databases/frome/2016/4/2016_4_26.h5
+2017-02-13 19:51:34,914 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:51:36,974 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:51:39,403 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:51:41,226 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:51:43,136 - INFO - Migrating: /databases/frome/2016/3/2016_3_27.h5
+2017-02-13 19:51:43,551 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:51:43,712 - INFO - Migrating: /databases/frome/2016/4/2016_4_1.h5
+2017-02-13 19:51:44,126 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:51:45,897 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:51:47,857 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:51:49,344 - INFO - Migrating: /databases/frome/2016/10/2016_10_16.h5
+2017-02-13 19:51:49,758 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:51:51,881 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:51:54,283 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:51:55,463 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:51:57,522 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:51:59,545 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:52:01,522 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:52:03,376 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:52:05,415 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:52:07,454 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:52:09,615 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 19:52:10,464 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:52:12,444 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:52:14,441 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:52:16,398 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:52:18,335 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:52:20,335 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:52:22,878 - INFO - Migrating: /databases/frome/2017/1/2017_1_15.h5
+2017-02-13 19:52:23,294 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:52:26,466 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:52:28,113 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:52:30,441 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:52:32,324 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:52:33,877 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:52:35,473 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:52:37,084 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:52:38,666 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 19:52:39,170 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:52:40,744 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:52:42,349 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:52:43,852 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:52:45,402 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:52:46,890 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 19:52:48,434 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:52:49,970 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:52:51,529 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:52:53,403 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:52:55,026 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:52:57,227 - INFO - Migrating: /databases/frome/2016/8/2016_8_26.h5
+2017-02-13 19:52:57,667 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:52:59,930 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:53:02,682 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:53:04,116 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:53:06,266 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:53:08,415 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:53:10,020 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:53:12,058 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:53:14,059 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:53:16,104 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:53:18,272 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:53:20,342 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:53:22,396 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:53:24,471 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:53:26,353 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:53:28,446 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:53:31,077 - INFO - Migrating: /databases/frome/2016/10/2016_10_13.h5
+2017-02-13 19:53:31,491 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:53:34,519 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:53:34,584 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:53:37,127 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:53:38,717 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:53:40,750 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:53:42,687 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:53:44,706 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:53:46,669 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:53:46,811 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:53:48,764 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:53:50,691 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:53:52,721 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:53:54,741 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:53:56,706 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:53:58,683 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:54:00,774 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:54:02,647 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:54:04,613 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_92/singles
+2017-02-13 19:54:04,669 - ERROR - No information in HiSPARCNetwork() for sn 92
+2017-02-13 19:54:05,220 - INFO - Migrating: /databases/frome/2016/5/2016_5_31.h5
+2017-02-13 19:54:05,667 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:54:08,357 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:54:10,684 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:54:12,286 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:54:13,801 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:54:15,561 - INFO - Migrating: /databases/frome/2016/5/2016_5_3.h5
+2017-02-13 19:54:16,018 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:54:17,834 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:54:19,568 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:54:21,267 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:54:23,095 - INFO - Migrating: /databases/frome/2017/2/2017_2_5.h5
+2017-02-13 19:54:23,510 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:54:25,268 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:54:27,004 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:54:28,803 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:54:30,341 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:54:31,969 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:54:33,525 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:54:35,131 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:54:36,731 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 19:54:38,297 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 19:54:38,607 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:54:40,219 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:54:41,836 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:54:43,615 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:54:44,053 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 19:54:45,553 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:54:46,999 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:54:48,606 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:54:50,806 - INFO - Migrating: /databases/frome/2016/7/2016_7_17.h5
+2017-02-13 19:54:51,221 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:54:54,441 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:54:56,941 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:54:58,834 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:55:00,758 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:55:02,613 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:55:04,460 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:55:06,205 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:55:08,262 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:55:10,190 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:55:12,004 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:55:14,194 - INFO - Migrating: /databases/frome/2016/12/2016_12_5.h5
+2017-02-13 19:55:14,636 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:55:16,850 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:55:16,862 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:55:18,504 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:55:19,365 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:55:21,014 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:55:23,075 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:55:24,620 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:55:26,083 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:55:27,553 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:55:29,105 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:55:30,606 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:55:31,990 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:55:33,459 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:55:35,011 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:55:36,489 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:55:38,059 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:55:39,578 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:55:40,973 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:55:43,069 - INFO - Migrating: /databases/frome/2016/6/2016_6_29.h5
+2017-02-13 19:55:43,484 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:55:46,175 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:55:47,751 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:55:48,408 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:55:49,891 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:55:51,842 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:55:53,523 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:55:54,985 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:55:56,344 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:55:58,035 - INFO - Migrating: /databases/frome/2016/12/2016_12_14.h5
+2017-02-13 19:55:58,451 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:56:00,831 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:56:02,293 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 19:56:02,305 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:56:04,682 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:56:06,482 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:56:07,590 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:56:09,316 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:56:11,035 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:56:12,772 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:56:13,453 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:56:15,194 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:56:16,209 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:56:18,170 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:56:19,912 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:56:21,838 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:56:23,559 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:56:25,197 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:56:26,838 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:56:28,573 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:56:30,819 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 19:56:30,987 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:56:32,858 - INFO - Migrating: /databases/frome/2016/4/2016_4_17.h5
+2017-02-13 19:56:33,299 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:56:35,706 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:56:38,736 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:56:40,887 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:56:43,134 - INFO - Migrating: /databases/frome/2016/8/2016_8_12.h5
+2017-02-13 19:56:43,550 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:56:45,527 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:56:47,394 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:56:49,194 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:56:51,075 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:56:52,629 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:56:54,377 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:56:56,149 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:56:57,775 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:56:59,537 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:57:01,252 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:57:02,935 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:57:04,606 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:57:06,255 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:57:08,492 - INFO - Migrating: /databases/frome/2016/12/2016_12_12.h5
+2017-02-13 19:57:08,904 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:57:11,568 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 19:57:13,020 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:57:14,693 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:57:17,107 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:57:18,098 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:57:19,913 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:57:21,847 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:57:23,601 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:57:25,200 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:57:26,867 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:57:28,096 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:57:29,875 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:57:31,634 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:57:32,321 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:57:33,968 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:57:35,670 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:57:37,328 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:57:39,041 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:57:40,720 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:57:43,394 - INFO - Migrating: /databases/frome/2016/8/2016_8_7.h5
+2017-02-13 19:57:43,837 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:57:45,800 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:57:47,255 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:57:48,631 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:57:49,933 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:57:51,179 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:57:51,515 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:57:53,096 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:57:55,976 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:57:57,730 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:57:59,227 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:58:00,617 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:58:02,400 - INFO - Migrating: /databases/frome/2016/7/2016_7_14.h5
+2017-02-13 19:58:02,855 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:58:06,443 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:58:09,305 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:58:11,761 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:58:14,147 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:58:16,591 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:58:19,010 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:58:20,191 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:58:21,597 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:58:23,984 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:58:26,362 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:58:29,140 - INFO - Migrating: /databases/frome/2016/11/2016_11_25.h5
+2017-02-13 19:58:29,555 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:58:31,615 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 19:58:32,673 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:58:35,096 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:58:36,667 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:58:38,405 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:58:40,035 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:58:41,622 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:58:43,300 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:58:44,973 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 19:58:46,499 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:58:48,101 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:58:49,776 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:58:51,351 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:58:53,386 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:58:55,034 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:58:56,679 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:58:58,296 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:59:00,464 - INFO - Migrating: /databases/frome/2016/8/2016_8_11.h5
+2017-02-13 19:59:00,905 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:59:03,518 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:59:05,789 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:59:07,451 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:59:09,004 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:59:10,562 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:59:12,067 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:59:13,511 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:59:15,020 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:59:16,630 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 19:59:18,160 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 19:59:19,590 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 19:59:21,022 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 19:59:23,020 - INFO - Migrating: /databases/frome/2016/9/2016_9_24.h5
+2017-02-13 19:59:23,435 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 19:59:27,092 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 19:59:30,009 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 19:59:32,634 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 19:59:35,387 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 19:59:37,983 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 19:59:40,566 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 19:59:43,164 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 19:59:45,760 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 19:59:48,230 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 19:59:50,939 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 19:59:53,473 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 19:59:55,967 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 19:59:58,994 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:00:01,579 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:00:04,469 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:00:07,044 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:00:09,787 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_91/singles
+2017-02-13 20:00:12,310 - ERROR - No information in HiSPARCNetwork() for sn 91
+2017-02-13 20:00:12,403 - INFO - Migrating: /databases/frome/2016/4/2016_4_25.h5
+2017-02-13 20:00:12,842 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:00:15,641 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:00:17,996 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:00:20,000 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:00:22,016 - INFO - Migrating: /databases/frome/2016/11/2016_11_23.h5
+2017-02-13 20:00:22,430 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:00:24,250 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:00:24,262 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:00:24,797 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:00:26,766 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:00:28,401 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:00:30,127 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:00:31,842 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:00:33,496 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:00:35,138 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:00:36,827 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:00:38,579 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:00:40,210 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:00:41,840 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:00:42,462 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:00:44,216 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:00:45,946 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:00:47,659 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:00:49,322 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:00:51,534 - INFO - Migrating: /databases/frome/2016/9/2016_9_9.h5
+2017-02-13 20:00:51,948 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:00:55,106 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:00:57,213 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:00:59,052 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:01:00,886 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:01:02,677 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:01:04,605 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:01:06,464 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:01:08,413 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:01:10,308 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:01:12,334 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:01:14,212 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:01:16,181 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:01:18,051 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:01:19,913 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:01:21,790 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:01:24,243 - INFO - Migrating: /databases/frome/2017/1/2017_1_30.h5
+2017-02-13 20:01:24,682 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:01:26,770 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:01:29,210 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:01:31,007 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:01:32,760 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:01:34,525 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:01:36,206 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:01:37,991 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:01:39,783 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:01:41,566 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:01:42,161 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:01:43,932 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:01:45,764 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:01:47,524 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:01:49,171 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:01:50,831 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:01:52,533 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:01:54,239 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:01:55,898 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:01:58,226 - INFO - Migrating: /databases/frome/2016/5/2016_5_24.h5
+2017-02-13 20:01:58,640 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:02:01,693 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:02:04,234 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:02:05,924 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:02:07,917 - INFO - Migrating: /databases/frome/2016/11/2016_11_11.h5
+2017-02-13 20:02:08,372 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:02:12,560 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:02:15,499 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:02:18,298 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:02:21,148 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:02:24,081 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:02:26,863 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:02:29,780 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:02:32,704 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:02:35,548 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:02:38,355 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:02:41,127 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:02:44,221 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:02:47,153 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:02:50,058 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:02:52,879 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 20:02:53,125 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:02:56,581 - INFO - Migrating: /databases/frome/2017/2/2017_2_2.h5
+2017-02-13 20:02:57,021 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:02:58,040 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:02:59,953 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:03:01,991 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:03:03,677 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:03:05,353 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:03:07,013 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:03:08,787 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:03:10,450 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:03:12,196 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:03:13,956 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:03:15,767 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:03:17,483 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:03:19,105 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:03:20,857 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:03:22,527 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:03:24,343 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:03:25,978 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:03:27,674 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:03:29,995 - INFO - Migrating: /databases/frome/2016/5/2016_5_14.h5
+2017-02-13 20:03:30,411 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:03:32,981 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:03:35,308 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:03:37,029 - INFO - Migrating: /databases/frome/2016/3/2016_3_10.h5
+2017-02-13 20:03:37,444 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:03:38,758 - INFO - Migrating: /databases/frome/2017/1/2017_1_17.h5
+2017-02-13 20:03:39,171 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:03:40,929 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:03:42,516 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:03:44,607 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:03:46,216 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:03:47,784 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:03:49,353 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:03:50,860 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:03:52,417 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:03:53,011 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:03:54,996 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:03:56,515 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:03:58,080 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:03:59,605 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:04:00,464 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:04:02,034 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:04:03,474 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:04:04,964 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:04:06,469 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:04:07,084 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 20:04:07,833 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:04:09,288 - INFO - Migrating: /databases/frome/2017/1/2017_1_4.h5
+2017-02-13 20:04:09,727 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:04:11,357 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:04:12,969 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:04:14,134 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:04:15,679 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:04:18,106 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:04:19,720 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:04:21,213 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:04:22,735 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:04:23,446 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:04:24,574 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:04:26,238 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:04:27,981 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:04:29,454 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:04:30,926 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:04:32,468 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:04:33,970 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:04:35,484 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:04:36,979 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:04:38,460 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:04:40,722 - INFO - Migrating: /databases/frome/2017/1/2017_1_20.h5
+2017-02-13 20:04:41,136 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:04:42,839 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:04:44,868 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:04:46,699 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:04:48,401 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:04:50,021 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:04:51,769 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:04:53,294 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:04:53,608 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:04:55,073 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:04:56,648 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:04:58,221 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:04:58,807 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:05:00,469 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:05:02,105 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:05:03,779 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:05:05,328 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:05:06,859 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:05:09,124 - INFO - Migrating: /databases/frome/2016/10/2016_10_14.h5
+2017-02-13 20:05:09,542 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:05:12,352 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:05:12,440 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:05:14,115 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:05:15,210 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:05:17,624 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:05:19,370 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:05:21,027 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:05:22,685 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:05:24,334 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:05:26,018 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:05:27,642 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 20:05:28,362 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:05:29,886 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:05:31,573 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:05:33,203 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:05:34,889 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:05:36,448 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:05:38,561 - INFO - Migrating: /databases/frome/2016/6/2016_6_26.h5
+2017-02-13 20:05:38,997 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:05:41,653 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:05:44,175 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:05:44,703 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:05:46,226 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:05:47,662 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:05:48,919 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:05:50,289 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:05:51,841 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:05:53,618 - INFO - Migrating: /databases/frome/2016/4/2016_4_2.h5
+2017-02-13 20:05:54,031 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:05:55,997 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:05:58,163 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:05:59,754 - INFO - Migrating: /databases/frome/2016/10/2016_10_12.h5
+2017-02-13 20:06:00,168 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:06:02,169 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:06:04,207 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:06:05,008 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:06:06,830 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:06:08,783 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:06:10,640 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:06:12,610 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:06:14,428 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:06:16,169 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:06:18,012 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:06:19,750 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:06:21,665 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:06:23,417 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:06:25,256 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:06:27,024 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:06:28,879 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:06:31,253 - INFO - Migrating: /databases/frome/2016/6/2016_6_19.h5
+2017-02-13 20:06:31,670 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:06:34,490 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:06:36,955 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:06:38,475 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:06:39,891 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:06:41,207 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:06:42,461 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:06:43,767 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:06:45,026 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:06:46,731 - INFO - Migrating: /databases/frome/2016/12/2016_12_7.h5
+2017-02-13 20:06:47,170 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:06:49,217 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:06:49,229 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:06:51,079 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:06:52,626 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:06:54,262 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:06:55,932 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:06:57,488 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:06:59,028 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:07:00,611 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:07:01,831 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:07:03,411 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:07:05,008 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:07:05,732 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:07:07,313 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:07:09,170 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:07:10,722 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:07:12,283 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:07:13,916 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:07:16,020 - INFO - Migrating: /databases/frome/2016/5/2016_5_6.h5
+2017-02-13 20:07:16,435 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:07:19,123 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:07:20,937 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:07:23,189 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:07:25,079 - INFO - Migrating: /databases/frome/2017/2/2017_2_8.h5
+2017-02-13 20:07:25,495 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:07:27,272 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:07:28,980 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:07:30,739 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:07:32,430 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:07:33,980 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:07:35,616 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:07:37,305 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:07:38,973 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:07:40,561 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:07:42,092 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:07:43,763 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:07:45,380 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:07:47,018 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:07:48,627 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:07:50,251 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:07:51,952 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:07:53,605 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:07:55,832 - INFO - Migrating: /databases/frome/2016/6/2016_6_21.h5
+2017-02-13 20:07:56,275 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:07:59,054 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:08:00,850 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:08:01,456 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:08:03,456 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:08:06,004 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:08:07,753 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:08:09,501 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:08:11,161 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:08:13,038 - INFO - Migrating: /databases/frome/2016/6/2016_6_12.h5
+2017-02-13 20:08:13,452 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:08:15,382 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:08:15,893 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:08:17,685 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:08:19,364 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:08:21,028 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_521/singles
+2017-02-13 20:08:22,919 - INFO - Migrating: /databases/frome/2017/1/2017_1_3.h5
+2017-02-13 20:08:23,335 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:08:25,377 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:08:27,008 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:08:28,581 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:08:30,698 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:08:32,216 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:08:33,747 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:08:35,267 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:08:36,798 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:08:37,343 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:08:38,670 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:08:40,237 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:08:41,821 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:08:43,443 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:08:44,913 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:08:46,505 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:08:48,101 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:08:49,560 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:08:51,047 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:08:52,576 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:08:54,790 - INFO - Migrating: /databases/frome/2016/4/2016_4_29.h5
+2017-02-13 20:08:55,244 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:08:57,844 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:09:00,668 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:09:03,101 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:09:05,757 - INFO - Migrating: /databases/frome/2016/6/2016_6_24.h5
+2017-02-13 20:09:06,196 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:09:07,908 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:09:09,550 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:09:10,222 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:09:11,664 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:09:13,034 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:09:14,357 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:09:15,714 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:09:17,487 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:09:18,847 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_93/singles
+2017-02-13 20:09:19,284 - ERROR - No information in HiSPARCNetwork() for sn 93
+2017-02-13 20:09:19,607 - INFO - Migrating: /databases/frome/2017/1/2017_1_6.h5
+2017-02-13 20:09:20,021 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:09:21,685 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:09:23,664 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:09:24,715 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:09:26,374 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:09:27,973 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:09:29,555 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:09:30,965 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:09:32,492 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:09:33,464 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:09:35,002 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:09:36,542 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:09:37,984 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:09:39,661 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:09:41,167 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:09:42,667 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:09:44,133 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:09:45,663 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:09:47,262 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:09:49,407 - INFO - Migrating: /databases/frome/2016/12/2016_12_1.h5
+2017-02-13 20:09:49,821 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:09:52,519 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:09:52,573 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:09:54,993 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:09:55,870 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:09:57,612 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:09:59,396 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:10:01,036 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:10:02,728 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:10:04,523 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:10:06,016 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:10:07,665 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:10:09,515 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:10:11,370 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:10:13,062 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:10:14,719 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:10:16,354 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:10:18,019 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:10:19,522 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:10:21,826 - INFO - Migrating: /databases/frome/2016/8/2016_8_14.h5
+2017-02-13 20:10:22,265 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:10:24,949 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:10:27,370 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:10:28,958 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:10:30,478 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:10:32,025 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:10:33,544 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:10:35,045 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:10:35,421 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:10:36,906 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:10:38,413 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:10:39,917 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:10:41,384 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:10:42,760 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:10:44,822 - INFO - Migrating: /databases/frome/2016/10/2016_10_26.h5
+2017-02-13 20:10:45,237 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:10:48,113 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:10:50,146 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:10:51,893 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:10:53,930 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:10:55,977 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:10:57,939 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:10:59,874 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:11:01,929 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:11:03,955 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:11:05,853 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:11:06,829 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:11:07,733 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:11:09,886 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:11:12,016 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:11:13,974 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:11:16,475 - INFO - Migrating: /databases/frome/2016/12/2016_12_10.h5
+2017-02-13 20:11:16,889 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:11:19,386 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:11:20,743 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:11:23,296 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:11:24,906 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:11:25,728 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:11:27,323 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:11:28,884 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:11:30,462 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:11:32,033 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:11:33,566 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:11:34,641 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:11:36,212 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:11:37,840 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:11:38,466 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:11:40,065 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:11:41,574 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:11:43,248 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:11:44,696 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:11:46,172 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:11:48,364 - INFO - Migrating: /databases/frome/2016/4/2016_4_27.h5
+2017-02-13 20:11:48,805 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:11:52,519 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:11:54,959 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:11:57,173 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:11:59,429 - INFO - Migrating: /databases/frome/2016/8/2016_8_16.h5
+2017-02-13 20:11:59,843 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:12:03,193 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:12:05,918 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:12:08,751 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:12:11,297 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:12:13,993 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:12:16,568 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:12:18,925 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:12:21,444 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:12:23,776 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:12:26,114 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:12:28,401 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:12:30,794 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:12:33,295 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:12:36,147 - INFO - Migrating: /databases/frome/2016/7/2016_7_25.h5
+2017-02-13 20:12:36,602 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:12:39,572 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:12:42,056 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:12:44,239 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:12:46,214 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:12:48,031 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:12:49,811 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:12:51,920 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:12:53,864 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:12:55,819 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:12:58,151 - INFO - Migrating: /databases/frome/2016/9/2016_9_4.h5
+2017-02-13 20:12:58,593 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:13:01,566 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:13:04,008 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:13:04,613 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:13:06,808 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:13:09,175 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:13:11,374 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:13:13,526 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:13:15,573 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:13:17,745 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:13:20,068 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:13:22,422 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:13:24,647 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:13:26,803 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:13:29,031 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:13:31,024 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:13:33,824 - INFO - Migrating: /databases/frome/2016/10/2016_10_5.h5
+2017-02-13 20:13:34,239 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:13:37,319 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:13:40,380 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:13:42,639 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:13:45,281 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:13:47,807 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:13:50,544 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:13:53,202 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:13:55,803 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:13:58,384 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:14:01,100 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:14:03,751 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 20:14:04,976 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:14:07,734 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:14:11,402 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:14:14,340 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:14:15,917 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:14:18,610 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:14:20,302 - INFO - Migrating: /databases/frome/2016/11/2016_11_21.h5
+2017-02-13 20:14:20,745 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:14:22,616 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:14:22,656 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:14:24,932 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:14:26,631 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:14:28,319 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:14:29,976 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:14:31,557 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:14:33,221 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:14:34,976 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:14:36,633 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:14:38,306 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:14:40,203 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:14:41,316 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:14:42,904 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:14:44,590 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:14:46,232 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:14:47,738 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:14:49,934 - INFO - Migrating: /databases/frome/2016/7/2016_7_23.h5
+2017-02-13 20:14:50,348 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:14:53,236 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:14:55,872 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:14:57,509 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:14:59,193 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:15:00,199 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:15:01,808 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:15:03,567 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:15:05,204 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:15:06,819 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:15:08,469 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:15:10,614 - INFO - Migrating: /databases/frome/2016/8/2016_8_19.h5
+2017-02-13 20:15:11,028 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:15:13,849 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:15:15,880 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:15:18,172 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:15:20,232 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:15:22,581 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:15:24,572 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:15:26,553 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:15:28,528 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:15:30,516 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:15:32,521 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:15:34,456 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:15:36,319 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:15:38,195 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:15:40,516 - INFO - Migrating: /databases/frome/2016/3/2016_3_26.h5
+2017-02-13 20:15:40,956 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:15:42,905 - INFO - Migrating: /databases/frome/2017/1/2017_1_29.h5
+2017-02-13 20:15:43,320 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:15:45,099 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:15:46,792 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:15:48,473 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:15:50,064 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:15:52,520 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:15:54,124 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:15:55,667 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:15:57,256 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:15:58,833 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:16:00,384 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:16:01,925 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:16:03,453 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:16:05,023 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:16:06,623 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:16:08,214 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:16:09,905 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:16:12,024 - INFO - Migrating: /databases/frome/2016/5/2016_5_17.h5
+2017-02-13 20:16:12,435 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:16:15,023 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:16:16,871 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:16:18,518 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:16:20,373 - INFO - Migrating: /databases/frome/2016/10/2016_10_18.h5
+2017-02-13 20:16:20,786 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:16:23,451 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:16:23,531 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:16:25,621 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:16:27,018 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:16:28,852 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:16:30,699 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:16:32,485 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:16:34,163 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:16:35,913 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:16:37,668 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:16:39,530 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:16:41,341 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:16:43,117 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:16:44,889 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:16:46,646 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:16:48,330 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:16:50,038 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 20:16:50,365 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:16:52,754 - INFO - Migrating: /databases/frome/2016/8/2016_8_28.h5
+2017-02-13 20:16:53,193 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:16:56,301 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:16:59,032 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:16:59,715 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:17:01,912 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:17:04,052 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:17:06,121 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:17:08,296 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:17:10,446 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:17:12,748 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:17:14,881 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:17:16,960 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:17:19,029 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:17:21,309 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:17:23,210 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:17:25,813 - INFO - Migrating: /databases/frome/2016/8/2016_8_23.h5
+2017-02-13 20:17:26,227 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:17:29,123 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:17:31,882 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:17:33,736 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:17:35,449 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:17:37,134 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:17:38,770 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:17:40,377 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:17:42,100 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:17:43,768 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:17:45,490 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:17:47,390 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:17:49,025 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:17:50,720 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:17:52,241 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:17:54,447 - INFO - Migrating: /databases/frome/2016/4/2016_4_11.h5
+2017-02-13 20:17:54,885 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:17:57,546 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:17:59,858 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:18:01,597 - INFO - Migrating: /databases/frome/2017/1/2017_1_9.h5
+2017-02-13 20:18:02,012 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:18:03,868 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:18:05,567 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:18:06,358 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:18:08,335 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:18:10,150 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:18:11,764 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:18:13,590 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:18:15,259 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:18:16,301 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:18:18,650 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:18:20,355 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:18:22,182 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:18:23,882 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:18:25,482 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:18:27,120 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:18:28,680 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:18:30,328 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:18:31,925 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:18:34,265 - INFO - Migrating: /databases/frome/2016/11/2016_11_9.h5
+2017-02-13 20:18:34,678 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:18:38,638 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:18:41,816 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:18:44,867 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:18:47,864 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:18:50,841 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:18:53,888 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:18:56,885 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:18:59,939 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:19:02,911 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:19:05,830 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:19:08,784 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:19:11,723 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:19:15,393 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:19:18,725 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:19:21,563 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 20:19:22,125 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:19:25,205 - INFO - Migrating: /databases/frome/2016/10/2016_10_23.h5
+2017-02-13 20:19:25,645 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:19:28,298 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:19:30,698 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:19:31,704 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:19:33,581 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:19:35,398 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:19:37,308 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:19:39,190 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:19:41,004 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:19:42,870 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:19:44,886 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:19:46,674 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:19:48,523 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:19:50,342 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:19:52,183 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:19:53,953 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:19:56,316 - INFO - Migrating: /databases/frome/2016/6/2016_6_28.h5
+2017-02-13 20:19:56,730 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:19:59,406 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:20:01,532 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:20:02,099 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:20:03,612 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:20:04,896 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:20:06,243 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 20:20:06,456 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:20:07,819 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:20:09,238 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:20:10,941 - INFO - Migrating: /databases/frome/2016/6/2016_6_23.h5
+2017-02-13 20:20:11,354 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:20:13,561 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:20:15,190 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:20:15,779 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:20:17,764 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:20:19,260 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:20:20,822 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:20:22,363 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:20:23,823 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:20:25,246 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_93/singles
+2017-02-13 20:20:25,847 - ERROR - No information in HiSPARCNetwork() for sn 93
+2017-02-13 20:20:26,185 - INFO - Migrating: /databases/frome/2016/9/2016_9_13.h5
+2017-02-13 20:20:26,623 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:20:30,863 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:20:31,029 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:20:33,885 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:20:36,655 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:20:39,449 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:20:42,169 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:20:43,896 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:20:46,793 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:20:49,481 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:20:52,114 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:20:54,747 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:20:57,480 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 20:20:58,884 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:21:01,636 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:21:04,848 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:21:07,962 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:21:10,773 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:21:13,751 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:21:16,771 - INFO - Migrating: /databases/frome/2016/7/2016_7_18.h5
+2017-02-13 20:21:17,184 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:21:19,469 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:21:21,873 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:21:23,852 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:21:25,832 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:21:27,892 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:21:29,906 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:21:31,929 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:21:34,026 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:21:36,194 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:21:38,440 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:21:40,787 - INFO - Migrating: /databases/frome/2017/1/2017_1_1.h5
+2017-02-13 20:21:41,229 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:21:43,637 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:21:45,359 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:21:47,047 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:21:48,696 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:21:50,371 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:21:52,807 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:21:54,524 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:21:56,290 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:21:56,901 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:21:58,629 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:22:00,295 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:22:01,994 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:22:03,623 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:22:05,261 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:22:06,932 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:22:08,623 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:22:10,497 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:22:12,221 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:22:13,774 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:22:16,156 - INFO - Migrating: /databases/frome/2017/1/2017_1_7.h5
+2017-02-13 20:22:16,570 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:22:18,330 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:22:19,948 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:22:21,097 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:22:23,396 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:22:25,048 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:22:26,603 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:22:28,045 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:22:29,554 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:22:30,491 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:22:32,070 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:22:33,665 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:22:35,182 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:22:36,768 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:22:38,251 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:22:39,731 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:22:41,316 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:22:42,827 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:22:44,372 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:22:46,562 - INFO - Migrating: /databases/frome/2016/12/2016_12_4.h5
+2017-02-13 20:22:47,002 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:22:49,859 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:22:52,357 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:22:53,533 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:22:55,339 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:22:57,078 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:22:58,858 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:23:00,470 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:23:02,181 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:23:03,878 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:23:05,503 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:23:07,156 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:23:08,828 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:23:10,665 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:23:12,434 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:23:14,196 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:23:15,940 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:23:17,500 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:23:19,897 - INFO - Migrating: /databases/frome/2016/6/2016_6_25.h5
+2017-02-13 20:23:20,312 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:23:23,019 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:23:25,714 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:23:26,223 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:23:27,925 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:23:29,517 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:23:31,077 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:23:32,535 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:23:34,037 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:23:35,921 - INFO - Migrating: /databases/frome/2017/1/2017_1_22.h5
+2017-02-13 20:23:36,335 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:23:39,565 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:23:41,908 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:23:43,489 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:23:45,012 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:23:46,517 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:23:48,027 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:23:49,519 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:23:50,012 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:23:51,595 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:23:53,067 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:23:54,600 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:23:55,696 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:23:57,392 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:23:59,068 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:24:00,595 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:24:02,197 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:24:03,759 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:24:05,818 - INFO - Migrating: /databases/frome/2016/7/2016_7_15.h5
+2017-02-13 20:24:06,258 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:24:09,873 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:24:12,301 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:24:14,809 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:24:17,195 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:24:19,296 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:24:21,582 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:24:23,684 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:24:25,703 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:24:27,791 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:24:29,963 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:24:32,330 - INFO - Migrating: /databases/frome/2016/12/2016_12_18.h5
+2017-02-13 20:24:32,742 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:24:36,299 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:24:37,748 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:24:40,732 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:24:43,624 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:24:46,523 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:24:49,247 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:24:52,272 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:24:55,281 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:24:58,051 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:25:00,915 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:25:01,588 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:25:04,387 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:25:07,229 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:25:10,912 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:25:13,910 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:25:16,841 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:25:17,468 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:25:20,351 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:25:23,401 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:25:26,353 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:25:29,359 - INFO - Migrating: /databases/frome/2016/12/2016_12_15.h5
+2017-02-13 20:25:29,837 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:25:32,295 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:25:34,142 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:25:34,181 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:25:36,232 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:25:38,276 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:25:40,095 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:25:42,050 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:25:44,322 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:25:46,195 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:25:46,850 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:25:48,756 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:25:50,608 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:25:52,605 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:25:54,514 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:25:56,418 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:25:58,318 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:26:00,222 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:26:02,249 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:26:04,891 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:26:07,012 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 20:26:07,119 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:26:09,330 - INFO - Migrating: /databases/frome/2016/4/2016_4_24.h5
+2017-02-13 20:26:09,745 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:26:11,825 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:26:14,431 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:26:16,290 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:26:18,159 - INFO - Migrating: /databases/frome/2017/2/2017_2_4.h5
+2017-02-13 20:26:18,574 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:26:20,544 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:26:22,691 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:26:24,487 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:26:26,263 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:26:27,933 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:26:29,619 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:26:31,372 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:26:33,054 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:26:34,837 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:26:35,165 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:26:36,927 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:26:38,684 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:26:40,296 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:26:40,623 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:26:42,338 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:26:44,045 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:26:45,775 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:26:47,577 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:26:48,429 - INFO - Migrating: /databases/frome/2016/8/2016_8_4.h5
+2017-02-13 20:26:48,870 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:26:51,710 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:26:53,980 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:26:55,762 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:26:57,443 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:26:59,063 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:27:00,784 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:27:02,335 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:27:04,016 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:27:05,694 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:27:07,311 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:27:08,957 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:27:11,231 - INFO - Migrating: /databases/frome/2016/8/2016_8_13.h5
+2017-02-13 20:27:11,644 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:27:13,691 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:27:15,639 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:27:17,316 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:27:18,850 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:27:20,357 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:27:21,988 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:27:23,521 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:27:23,999 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:27:25,484 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:27:27,051 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:27:28,518 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:27:29,995 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:27:31,368 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:27:33,335 - INFO - Migrating: /databases/frome/2017/1/2017_1_31.h5
+2017-02-13 20:27:33,749 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:27:36,400 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:27:38,666 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:27:39,602 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:27:41,209 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:27:42,787 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:27:44,300 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:27:45,929 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:27:47,491 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:27:49,060 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:27:50,807 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:27:52,359 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:27:53,890 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:27:55,540 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:27:57,044 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:27:58,602 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:28:00,147 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:28:01,714 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:28:03,312 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:28:05,424 - INFO - Migrating: /databases/frome/2016/11/2016_11_24.h5
+2017-02-13 20:28:05,868 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:28:08,485 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:28:08,618 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:28:08,674 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:28:10,759 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:28:12,693 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:28:14,522 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:28:16,120 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:28:17,650 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:28:19,148 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:28:20,747 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:28:22,553 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:28:24,033 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:28:25,559 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:28:27,115 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:28:28,139 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:28:29,735 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:28:31,264 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:28:32,802 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:28:34,359 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:28:36,542 - INFO - Migrating: /databases/frome/2016/7/2016_7_21.h5
+2017-02-13 20:28:36,957 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:28:38,730 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:28:40,358 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:28:41,962 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:28:43,640 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:28:46,443 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:28:48,155 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:28:49,820 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:28:51,396 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:28:53,167 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:28:54,713 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:28:56,622 - INFO - Migrating: /databases/frome/2016/5/2016_5_19.h5
+2017-02-13 20:28:57,036 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1102/singles
+2017-02-13 20:28:58,365 - ERROR - No information in HiSPARCNetwork() for sn 1102
+2017-02-13 20:28:58,373 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:29:00,717 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:29:02,478 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:29:04,132 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:29:05,873 - INFO - Migrating: /databases/frome/2016/3/2016_3_21.h5
+2017-02-13 20:29:06,353 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:29:07,665 - INFO - Migrating: /databases/frome/2016/10/2016_10_31.h5
+2017-02-13 20:29:08,080 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:29:10,229 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:29:10,241 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:29:12,698 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:29:13,949 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:29:15,920 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:29:18,007 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:29:19,915 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:29:21,899 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:29:24,076 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:29:26,025 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:29:28,000 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:29:29,964 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:29:31,932 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:29:33,354 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:29:35,323 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:29:37,229 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:29:39,848 - INFO - Migrating: /databases/frome/2016/12/2016_12_8.h5
+2017-02-13 20:29:40,262 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:29:43,069 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:29:43,116 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:29:45,718 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:29:46,726 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:29:47,638 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:29:49,372 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:29:51,231 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:29:52,930 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:29:54,868 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:29:56,621 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:29:57,647 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:29:59,355 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:30:01,103 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:30:01,887 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:30:03,611 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:30:05,339 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:30:07,101 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:30:08,801 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:30:10,594 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:30:13,163 - INFO - Migrating: /databases/frome/2016/8/2016_8_30.h5
+2017-02-13 20:30:13,606 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:30:16,297 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:30:18,943 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:30:19,541 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:30:21,892 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:30:23,971 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:30:25,970 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:30:27,915 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:30:29,919 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:30:31,902 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:30:33,923 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:30:35,948 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:30:37,889 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:30:39,832 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:30:41,821 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:30:44,314 - INFO - Migrating: /databases/frome/2016/5/2016_5_15.h5
+2017-02-13 20:30:44,728 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:30:47,012 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:30:48,754 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:30:50,529 - INFO - Migrating: /databases/frome/2016/5/2016_5_29.h5
+2017-02-13 20:30:50,943 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:30:52,812 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:30:55,133 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:30:57,117 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:30:58,979 - INFO - Migrating: /databases/frome/2017/1/2017_1_19.h5
+2017-02-13 20:30:59,393 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:31:01,211 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:31:02,979 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:31:04,838 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:31:06,510 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:31:07,772 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:31:09,612 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:31:11,203 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:31:12,901 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:31:13,412 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:31:14,985 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:31:16,526 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:31:18,186 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:31:18,749 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:31:20,323 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:31:22,197 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:31:23,792 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:31:25,342 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:31:26,974 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:31:29,244 - INFO - Migrating: /databases/frome/2016/3/2016_3_31.h5
+2017-02-13 20:31:29,685 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:31:32,353 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:31:33,871 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:31:36,648 - INFO - Migrating: /databases/frome/2016/4/2016_4_18.h5
+2017-02-13 20:31:37,064 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:31:39,286 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:31:41,321 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:31:43,073 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:31:44,978 - INFO - Migrating: /databases/frome/2016/7/2016_7_10.h5
+2017-02-13 20:31:45,392 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:31:47,181 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:31:48,870 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:31:49,509 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:31:51,340 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:31:53,153 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:31:54,655 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:31:56,128 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:31:57,598 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:31:59,362 - INFO - Migrating: /databases/frome/2017/2/2017_2_11.h5
+2017-02-13 20:31:59,818 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:32:02,487 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:32:04,701 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:32:06,487 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:32:08,246 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:32:09,912 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:32:11,734 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:32:13,460 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:32:15,079 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:32:16,857 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:32:18,622 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:32:20,243 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:32:21,924 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:32:23,545 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:32:25,246 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:32:26,980 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:32:28,550 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:32:30,179 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:32:32,423 - INFO - Migrating: /databases/frome/2016/10/2016_10_15.h5
+2017-02-13 20:32:32,863 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:32:35,395 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:32:37,758 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:32:39,156 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:32:41,024 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:32:42,882 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:32:44,651 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:32:46,379 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:32:48,135 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:32:49,962 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:32:51,788 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 20:32:53,914 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:32:55,777 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:32:57,555 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:32:59,388 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:33:01,149 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:33:02,995 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:33:05,271 - INFO - Migrating: /databases/frome/2016/10/2016_10_24.h5
+2017-02-13 20:33:05,686 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:33:09,075 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:33:11,717 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:33:12,977 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:33:15,242 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:33:17,540 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:33:19,723 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:33:21,929 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:33:24,249 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:33:26,448 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:33:28,736 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:33:30,883 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:33:32,233 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:33:34,441 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:33:36,511 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:33:38,763 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:33:41,509 - INFO - Migrating: /databases/frome/2017/1/2017_1_2.h5
+2017-02-13 20:33:41,951 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:33:44,534 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:33:46,905 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:33:48,528 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:33:50,090 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:33:51,552 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:33:53,547 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:33:55,866 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:33:57,436 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:33:58,051 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:33:59,704 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:34:01,319 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:34:02,952 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:34:04,392 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:34:06,036 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:34:07,496 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:34:09,010 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:34:10,578 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:34:12,358 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:34:13,935 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:34:17,176 - INFO - Migrating: /databases/frome/2016/6/2016_6_20.h5
+2017-02-13 20:34:17,592 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:34:19,445 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:34:21,241 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:34:22,265 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:34:24,819 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:34:26,513 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:34:28,215 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:34:29,946 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:34:31,549 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:34:33,527 - INFO - Migrating: /databases/frome/2016/12/2016_12_6.h5
+2017-02-13 20:34:33,941 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:34:37,884 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:34:37,964 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:34:39,810 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:34:40,782 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:34:42,509 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:34:44,270 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:34:45,999 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:34:47,815 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:34:49,451 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:34:51,140 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:34:52,734 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:34:54,602 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:34:55,868 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:34:57,507 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:34:59,187 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:35:00,806 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:35:02,445 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:35:04,081 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:35:06,343 - INFO - Migrating: /databases/frome/2016/6/2016_6_1.h5
+2017-02-13 20:35:06,783 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:35:08,331 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:35:09,559 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:35:12,206 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:35:13,762 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:35:15,371 - INFO - Migrating: /databases/frome/2016/9/2016_9_23.h5
+2017-02-13 20:35:15,785 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:35:18,936 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:35:22,231 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:35:24,989 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:35:27,813 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:35:30,351 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:35:33,229 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:35:35,909 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:35:38,562 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:35:41,211 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:35:43,962 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:35:46,589 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:35:49,328 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:35:52,034 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:35:55,351 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:35:58,434 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:36:01,269 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:36:04,200 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_91/singles
+2017-02-13 20:36:05,168 - ERROR - No information in HiSPARCNetwork() for sn 91
+2017-02-13 20:36:05,234 - INFO - Migrating: /databases/frome/2017/2/2017_2_13.h5
+2017-02-13 20:36:05,649 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:36:06,542 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:36:07,420 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:36:08,229 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:36:08,958 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:36:09,701 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:36:10,436 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:36:11,087 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:36:11,832 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:36:12,593 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:36:13,725 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:36:14,410 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:36:15,102 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:36:15,768 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:36:16,383 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:36:17,040 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:36:17,822 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:36:18,770 - INFO - Migrating: /databases/frome/2016/9/2016_9_11.h5
+2017-02-13 20:36:19,251 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:36:21,765 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:36:24,235 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:36:26,201 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:36:28,100 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:36:29,892 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:36:31,715 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:36:33,586 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:36:35,460 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:36:37,331 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:36:39,393 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:36:41,223 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:36:43,156 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:36:45,055 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:36:46,896 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:36:48,890 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:36:51,306 - INFO - Migrating: /databases/frome/2016/7/2016_7_29.h5
+2017-02-13 20:36:51,720 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:36:54,800 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:36:57,249 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:36:59,035 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:37:00,816 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:37:02,663 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:37:04,381 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:37:06,060 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:37:07,798 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:37:09,600 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:37:11,369 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:37:13,681 - INFO - Migrating: /databases/frome/2016/8/2016_8_3.h5
+2017-02-13 20:37:14,095 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:37:17,125 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:37:19,359 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:37:20,101 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:37:22,599 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:37:24,724 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:37:26,849 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:37:28,923 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:37:30,919 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:37:32,935 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:37:35,151 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:37:37,214 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:37:39,591 - INFO - Migrating: /databases/frome/2016/11/2016_11_27.h5
+2017-02-13 20:37:40,031 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:37:42,400 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:37:43,568 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:37:45,820 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:37:47,421 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:37:49,016 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:37:50,490 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:37:52,034 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:37:53,783 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:37:55,383 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:37:56,916 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:37:58,411 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:37:59,948 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:38:01,417 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:38:02,897 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:38:04,382 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:38:05,806 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:38:07,272 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:38:09,377 - INFO - Migrating: /databases/frome/2016/7/2016_7_24.h5
+2017-02-13 20:38:09,792 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:38:13,941 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:38:15,802 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:38:17,562 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:38:19,305 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:38:21,022 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:38:22,722 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:38:24,668 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:38:26,433 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:38:28,177 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:38:30,129 - INFO - Migrating: /databases/frome/2016/8/2016_8_1.h5
+2017-02-13 20:38:30,544 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:38:33,122 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:38:35,819 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:38:37,716 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:38:39,378 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:38:40,873 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:38:42,695 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:38:44,414 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:38:46,255 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:38:48,111 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:38:49,965 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:38:52,198 - INFO - Migrating: /databases/frome/2016/12/2016_12_20.h5
+2017-02-13 20:38:52,638 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:38:56,889 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:38:57,562 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:38:57,728 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:39:00,958 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:39:03,783 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:39:06,742 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:39:09,561 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:39:12,473 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:39:15,340 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:39:18,264 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:39:21,235 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:39:21,905 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:39:24,995 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:39:26,805 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:39:30,136 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:39:33,108 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:39:36,203 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:39:37,306 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:39:40,230 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:39:43,344 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:39:46,150 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:39:49,231 - INFO - Migrating: /databases/frome/2016/10/2016_10_4.h5
+2017-02-13 20:39:49,644 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:39:52,687 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:39:52,722 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:39:55,914 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:39:58,711 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:40:01,533 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:40:04,308 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:40:07,052 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:40:09,816 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:40:12,759 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:40:15,424 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:40:18,150 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:40:20,949 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:40:24,216 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:40:27,075 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:40:29,789 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:40:31,517 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:40:34,193 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:40:36,163 - INFO - Migrating: /databases/frome/2016/11/2016_11_2.h5
+2017-02-13 20:40:36,603 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:40:39,302 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:40:41,317 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:40:42,863 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:40:44,830 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:40:46,850 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:40:48,873 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:40:50,803 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:40:52,896 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:40:54,797 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:40:56,674 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:40:58,527 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:41:00,394 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:41:02,300 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:41:04,301 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:41:06,273 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:41:08,255 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:41:10,791 - INFO - Migrating: /databases/frome/2016/9/2016_9_28.h5
+2017-02-13 20:41:11,244 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:41:15,708 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:41:15,751 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:41:18,734 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:41:21,818 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:41:24,755 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:41:27,475 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:41:30,471 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:41:33,222 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:41:36,237 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:41:38,865 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:41:41,789 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:41:44,680 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:41:47,487 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:41:50,801 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:41:53,826 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:41:56,552 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:41:59,304 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:42:02,309 - INFO - Migrating: /databases/frome/2016/4/2016_4_12.h5
+2017-02-13 20:42:02,753 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:42:05,847 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:42:07,583 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:42:09,826 - INFO - Migrating: /databases/frome/2016/12/2016_12_27.h5
+2017-02-13 20:42:10,241 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:42:12,788 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:42:15,177 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:42:17,480 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:42:19,735 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:42:21,976 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:42:24,376 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:42:26,654 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:42:28,921 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:42:29,530 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:42:31,836 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:42:34,152 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:42:36,457 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:42:38,644 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:42:40,950 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:42:43,638 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:42:45,857 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:42:48,185 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:42:50,500 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:42:53,309 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:42:55,812 - INFO - Migrating: /databases/frome/2016/4/2016_4_14.h5
+2017-02-13 20:42:56,226 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:42:56,347 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:42:58,212 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:42:59,743 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:43:01,782 - INFO - Migrating: /databases/frome/2016/12/2016_12_22.h5
+2017-02-13 20:43:02,197 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:43:02,244 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:43:05,198 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:43:08,032 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:43:10,803 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:43:13,588 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:43:16,263 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:43:18,982 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:43:21,618 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:43:24,412 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:43:25,093 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:43:27,908 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:43:28,626 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:43:31,376 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:43:34,407 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:43:37,255 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:43:40,082 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:43:42,742 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:43:45,542 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:43:48,289 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:43:51,330 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:43:54,412 - INFO - Migrating: /databases/frome/2017/1/2017_1_8.h5
+2017-02-13 20:43:54,851 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:43:57,210 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:43:59,080 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:44:00,066 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:44:01,671 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:44:03,257 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:44:04,854 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:44:06,359 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:44:08,112 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:44:09,023 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:44:10,689 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:44:12,282 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:44:14,064 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:44:15,929 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:44:17,477 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:44:18,973 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:44:20,417 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:44:21,846 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:44:23,483 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:44:25,612 - INFO - Migrating: /databases/frome/2016/5/2016_5_9.h5
+2017-02-13 20:44:26,027 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:44:27,648 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:44:30,025 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:44:31,875 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:44:33,645 - INFO - Migrating: /databases/frome/2016/7/2016_7_16.h5
+2017-02-13 20:44:34,060 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:44:36,561 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:44:39,042 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:44:41,180 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:44:43,210 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:44:44,719 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:44:46,805 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:44:48,878 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:44:50,882 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:44:52,873 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:44:55,126 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:44:57,573 - INFO - Migrating: /databases/frome/2016/10/2016_10_30.h5
+2017-02-13 20:44:58,013 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:45:01,866 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:45:04,803 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:45:05,979 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:45:09,034 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:45:11,910 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:45:14,738 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:45:17,501 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:45:20,252 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:45:23,106 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:45:25,859 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:45:28,650 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:45:31,419 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:45:31,936 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:45:36,415 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:45:39,357 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:45:42,390 - INFO - Migrating: /databases/frome/2016/8/2016_8_9.h5
+2017-02-13 20:45:42,846 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:45:44,741 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:45:46,450 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:45:48,060 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:45:48,561 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:45:50,080 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:45:52,123 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:45:53,730 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:45:55,225 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:45:56,737 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:45:58,256 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:45:59,826 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:46:01,280 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:46:03,221 - INFO - Migrating: /databases/frome/2016/9/2016_9_21.h5
+2017-02-13 20:46:03,662 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:46:07,662 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:46:10,450 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:46:13,174 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:46:15,916 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:46:18,754 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:46:21,548 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:46:23,919 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:46:26,508 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:46:28,177 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:46:30,758 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:46:33,751 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 20:46:34,968 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:46:37,512 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:46:40,588 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:46:43,483 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:46:46,312 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:46:49,158 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:46:51,963 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_91/singles
+2017-02-13 20:46:52,231 - ERROR - No information in HiSPARCNetwork() for sn 91
+2017-02-13 20:46:52,415 - INFO - Migrating: /databases/frome/2017/2/2017_2_1.h5
+2017-02-13 20:46:52,831 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:46:54,590 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:46:56,289 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:46:57,981 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:46:59,809 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:47:01,341 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:47:02,898 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:47:04,366 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:47:05,935 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:47:07,545 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:47:09,063 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:47:10,590 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:47:12,297 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:47:13,906 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:47:15,480 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:47:17,024 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:47:18,555 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:47:20,037 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:47:22,102 - INFO - Migrating: /databases/frome/2016/6/2016_6_22.h5
+2017-02-13 20:47:22,544 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:47:24,991 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:47:26,499 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:47:27,045 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:47:28,429 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:47:30,443 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:47:31,946 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 20:47:31,957 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:47:33,156 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:47:34,454 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:47:36,194 - INFO - Migrating: /databases/frome/2017/1/2017_1_12.h5
+2017-02-13 20:47:36,610 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:47:37,653 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:47:39,261 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:47:40,125 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:47:41,715 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:47:44,068 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:47:45,654 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:47:47,138 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:47:48,810 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:47:50,373 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:47:52,285 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:47:53,952 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:47:55,581 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:47:57,100 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:47:58,661 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:48:00,142 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:48:01,706 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:48:03,247 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:48:04,776 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:48:06,348 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:48:08,582 - INFO - Migrating: /databases/frome/2016/9/2016_9_16.h5
+2017-02-13 20:48:08,996 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:48:12,236 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:48:12,287 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:48:15,523 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:48:18,378 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:48:21,170 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:48:23,930 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:48:26,665 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:48:29,463 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:48:32,114 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:48:34,931 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:48:37,707 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:48:40,643 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 20:48:41,077 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:48:44,339 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:48:47,255 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:48:50,022 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:48:52,956 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:48:55,628 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:48:58,753 - INFO - Migrating: /databases/frome/2016/11/2016_11_10.h5
+2017-02-13 20:48:59,197 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:49:04,060 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:49:07,212 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:49:10,318 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:49:13,501 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:49:16,533 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:49:19,421 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:49:22,379 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:49:25,568 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:49:28,571 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:49:31,773 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:49:34,712 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:49:37,728 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:49:41,485 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:49:44,778 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:49:47,807 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:49:51,177 - INFO - Migrating: /databases/frome/2017/2/2017_2_9.h5
+2017-02-13 20:49:51,592 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:49:53,843 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:49:56,176 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:49:57,843 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:49:59,451 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:50:01,090 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:50:02,630 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:50:04,217 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:50:05,726 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:50:07,376 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:50:09,076 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:50:10,695 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:50:12,430 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:50:14,201 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:50:15,843 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:50:17,409 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:50:19,025 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:50:20,645 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:50:22,862 - INFO - Migrating: /databases/frome/2017/1/2017_1_14.h5
+2017-02-13 20:50:23,303 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:50:25,919 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:50:28,473 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:50:30,162 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:50:31,751 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:50:33,342 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:50:34,859 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:50:36,386 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:50:37,934 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:50:38,433 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:50:40,037 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:50:41,596 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:50:43,410 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:50:44,900 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:50:46,484 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:50:47,986 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:50:49,501 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:50:51,139 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:50:52,719 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:50:54,310 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:50:56,850 - INFO - Migrating: /databases/frome/2016/9/2016_9_14.h5
+2017-02-13 20:50:57,264 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:51:00,293 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:51:03,558 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:51:06,281 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:51:09,042 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:51:11,781 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:51:13,489 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:51:16,504 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:51:19,248 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:51:21,971 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:51:24,779 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:51:27,564 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:51:30,165 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:51:33,421 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:51:36,118 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:51:39,101 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:51:41,766 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:51:44,705 - INFO - Migrating: /databases/frome/2016/4/2016_4_23.h5
+2017-02-13 20:51:45,145 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:51:48,187 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:51:50,189 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:51:52,187 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:51:54,573 - INFO - Migrating: /databases/frome/2016/4/2016_4_6.h5
+2017-02-13 20:51:54,987 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:51:56,581 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:51:58,329 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:51:59,974 - INFO - Migrating: /databases/frome/2016/5/2016_5_30.h5
+2017-02-13 20:52:00,389 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:52:01,465 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:52:03,410 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:52:05,605 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:52:07,385 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:52:09,430 - INFO - Migrating: /databases/frome/2016/4/2016_4_7.h5
+2017-02-13 20:52:09,844 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:52:11,571 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:52:13,146 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:52:15,271 - INFO - Migrating: /databases/frome/2016/12/2016_12_25.h5
+2017-02-13 20:52:15,686 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:52:18,308 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:52:20,778 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:52:23,522 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:52:25,979 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:52:28,455 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:52:30,819 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:52:33,305 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:52:35,850 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:52:36,487 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:52:38,950 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:52:41,260 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:52:43,614 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:52:45,966 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:52:48,220 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:52:50,609 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:52:53,561 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:52:55,968 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:52:58,877 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:53:01,293 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:53:03,841 - INFO - Migrating: /databases/frome/2016/4/2016_4_16.h5
+2017-02-13 20:53:04,280 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:53:06,601 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:53:09,121 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:53:11,260 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:53:13,819 - INFO - Migrating: /databases/frome/2016/12/2016_12_23.h5
+2017-02-13 20:53:14,231 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:53:17,726 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:53:20,480 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:53:23,468 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:53:26,272 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:53:29,186 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:53:31,993 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:53:34,729 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:53:37,596 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:53:38,288 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:53:41,095 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:53:44,336 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:53:47,009 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:53:50,255 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:53:53,150 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:53:56,094 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:53:58,953 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:54:01,632 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:54:04,585 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:54:07,452 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 20:54:07,910 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:54:10,897 - INFO - Migrating: /databases/frome/2016/4/2016_4_19.h5
+2017-02-13 20:54:11,340 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:54:13,653 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:54:16,406 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:54:18,710 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:54:20,991 - INFO - Migrating: /databases/frome/2016/8/2016_8_31.h5
+2017-02-13 20:54:21,447 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:54:23,781 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:54:25,889 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:54:26,496 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:54:28,771 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:54:30,820 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:54:32,796 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:54:34,807 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:54:36,837 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:54:38,810 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:54:40,685 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:54:42,982 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:54:45,085 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:54:46,993 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:54:48,913 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:54:51,335 - INFO - Migrating: /databases/frome/2016/10/2016_10_10.h5
+2017-02-13 20:54:51,750 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:54:55,772 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:54:55,832 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:54:58,535 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:54:59,468 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:55:02,162 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:55:04,746 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:55:07,196 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:55:09,743 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:55:12,315 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:55:14,830 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:55:17,201 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:55:19,699 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:55:22,184 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:55:24,414 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:55:24,981 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:55:27,692 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:55:30,659 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:55:33,545 - INFO - Migrating: /databases/frome/2017/2/2017_2_3.h5
+2017-02-13 20:55:33,985 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:55:36,135 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:55:38,216 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:55:39,898 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:55:41,393 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:55:42,969 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:55:44,610 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:55:46,212 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:55:47,840 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 20:55:49,380 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:55:50,454 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:55:51,975 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:55:53,884 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:55:55,451 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:55:57,036 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:55:58,614 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:56:00,148 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:56:01,696 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:56:03,331 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:56:05,591 - INFO - Migrating: /databases/frome/2016/6/2016_6_7.h5
+2017-02-13 20:56:06,007 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:56:08,468 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:56:09,468 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:56:09,506 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:56:11,709 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:56:13,462 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:56:15,338 - INFO - Migrating: /databases/frome/2016/4/2016_4_9.h5
+2017-02-13 20:56:15,753 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:56:17,845 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:56:19,408 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:56:21,356 - INFO - Migrating: /databases/frome/2016/5/2016_5_13.h5
+2017-02-13 20:56:21,771 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:56:24,101 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:56:26,141 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:56:27,573 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:56:29,465 - INFO - Migrating: /databases/frome/2016/2/2016_2_26.h5
+2017-02-13 20:56:29,881 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:56:29,932 - INFO - Migrating: /databases/frome/2016/8/2016_8_2.h5
+2017-02-13 20:56:30,345 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:56:32,858 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:56:34,857 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:56:36,302 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:56:37,828 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:56:39,304 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:56:40,838 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:56:42,386 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:56:43,819 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:56:45,319 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:56:46,723 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:56:48,582 - INFO - Migrating: /databases/frome/2017/1/2017_1_16.h5
+2017-02-13 20:56:49,024 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 20:56:50,707 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:56:52,275 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:56:54,612 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:56:56,116 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:56:57,607 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:56:59,114 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:57:00,641 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:57:02,177 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 20:57:02,616 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:57:04,161 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:57:05,645 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:57:07,075 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:57:08,745 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:57:10,292 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 20:57:11,768 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:57:13,256 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:57:14,816 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:57:16,375 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:57:17,878 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:57:20,113 - INFO - Migrating: /databases/frome/2016/12/2016_12_2.h5
+2017-02-13 20:57:20,528 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:57:22,302 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 20:57:22,314 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 20:57:23,945 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:57:24,932 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:57:26,603 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:57:28,969 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:57:30,559 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:57:32,166 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:57:33,779 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:57:35,043 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 20:57:36,714 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:57:38,313 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:57:40,081 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:57:41,628 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:57:43,292 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:57:44,899 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:57:46,503 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:57:48,132 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:57:50,341 - INFO - Migrating: /databases/frome/2016/10/2016_10_29.h5
+2017-02-13 20:57:50,780 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:57:54,542 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:57:57,909 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:57:59,136 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:58:02,297 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:58:05,235 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:58:08,140 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:58:10,876 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:58:14,059 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:58:17,050 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:58:20,042 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:58:23,104 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:58:26,080 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:58:27,179 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:58:30,661 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:58:33,981 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:58:37,032 - INFO - Migrating: /databases/frome/2016/3/2016_3_19.h5
+2017-02-13 20:58:37,449 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:58:38,907 - INFO - Migrating: /databases/frome/2016/11/2016_11_5.h5
+2017-02-13 20:58:39,323 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:58:42,500 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:58:45,673 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:58:46,810 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:58:49,792 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 20:58:52,920 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 20:58:55,889 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 20:58:58,721 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:59:01,788 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:59:04,848 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:59:07,774 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 20:59:10,755 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 20:59:14,029 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 20:59:17,094 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 20:59:19,990 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:59:23,145 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:59:26,433 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:59:29,507 - INFO - Migrating: /databases/frome/2016/5/2016_5_12.h5
+2017-02-13 20:59:29,945 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:59:32,888 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:59:34,990 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:59:36,554 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:59:38,339 - INFO - Migrating: /databases/frome/2016/6/2016_6_18.h5
+2017-02-13 20:59:38,754 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:59:40,583 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:59:42,479 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:59:43,961 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 20:59:45,414 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 20:59:46,760 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 20:59:48,110 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 20:59:49,188 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 20:59:50,307 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 20:59:51,703 - INFO - Migrating: /databases/frome/2016/9/2016_9_2.h5
+2017-02-13 20:59:52,117 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 20:59:54,596 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 20:59:56,539 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 20:59:57,120 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 20:59:59,132 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:00:01,278 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:00:03,050 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:00:04,853 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:00:06,622 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:00:08,267 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:00:10,010 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:00:11,932 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:00:13,643 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:00:15,386 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:00:17,202 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:00:19,442 - INFO - Migrating: /databases/frome/2016/8/2016_8_6.h5
+2017-02-13 21:00:19,856 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:00:23,533 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:00:25,502 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:00:27,091 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:00:28,715 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:00:30,217 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:00:30,754 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:00:32,284 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:00:33,745 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:00:35,193 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:00:36,681 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:00:38,139 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:00:40,360 - INFO - Migrating: /databases/frome/2016/11/2016_11_26.h5
+2017-02-13 21:00:40,799 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:00:43,390 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:00:44,178 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:00:46,303 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:00:47,948 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:00:49,623 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:00:51,462 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:00:53,146 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:00:54,777 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:00:56,407 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:00:58,051 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:00:59,611 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:01:01,189 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:01:02,832 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:01:04,393 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:01:06,022 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:01:07,627 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:01:09,233 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:01:11,453 - INFO - Migrating: /databases/frome/2016/11/2016_11_28.h5
+2017-02-13 21:01:11,868 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:01:14,604 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:01:14,617 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:01:16,167 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:01:17,853 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:01:19,528 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:01:21,440 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:01:23,370 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:01:24,954 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:01:26,660 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:01:28,211 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:01:29,718 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:01:31,265 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:01:32,802 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:01:34,389 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:01:36,019 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:01:37,646 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:01:39,161 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:01:40,673 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:01:42,803 - INFO - Migrating: /databases/frome/2016/12/2016_12_29.h5
+2017-02-13 21:01:43,283 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:01:45,688 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:01:47,791 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:01:49,584 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:01:51,134 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:01:52,685 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:01:54,411 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:01:56,053 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:01:57,658 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:01:58,228 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:01:59,838 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:02:01,415 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:02:02,974 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:02:04,577 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:02:06,150 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:02:07,772 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:02:09,336 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:02:10,830 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:02:12,413 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:02:13,925 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:02:16,694 - INFO - Migrating: /databases/frome/2016/3/2016_3_22.h5
+2017-02-13 21:02:17,108 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:02:17,706 - INFO - Migrating: /databases/frome/2016/4/2016_4_13.h5
+2017-02-13 21:02:18,122 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:02:20,032 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:02:22,587 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:02:24,582 - INFO - Migrating: /databases/frome/2016/10/2016_10_25.h5
+2017-02-13 21:02:24,996 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:02:27,399 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:02:29,771 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:02:30,799 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:02:33,096 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:02:35,270 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:02:37,609 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:02:39,942 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:02:42,335 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:02:44,610 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:02:46,876 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:02:48,412 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:02:50,045 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:02:52,339 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:02:54,541 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:02:56,820 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:02:59,563 - INFO - Migrating: /databases/frome/2016/10/2016_10_9.h5
+2017-02-13 21:03:00,003 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:03:02,568 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:03:05,371 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:03:06,197 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:03:08,624 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:03:10,975 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:03:13,322 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:03:15,586 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:03:17,847 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:03:20,105 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:03:22,410 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:03:24,685 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:03:26,859 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:03:29,037 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:03:29,540 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:03:31,859 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:03:34,482 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:03:35,491 - INFO - Migrating: /databases/frome/2016/3/2016_3_29.h5
+2017-02-13 21:03:35,906 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:03:36,916 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:03:37,755 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:03:38,599 - INFO - Migrating: /databases/frome/2016/12/2016_12_28.h5
+2017-02-13 21:03:39,014 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:03:40,962 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:03:43,648 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:03:45,726 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:03:47,635 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:03:49,520 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:03:51,294 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:03:53,609 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:03:55,632 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:03:56,224 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:03:58,257 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:04:00,172 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:04:02,053 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:04:03,903 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:04:05,831 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:04:07,716 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:04:09,593 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:04:11,496 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:04:14,113 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:04:16,132 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:04:18,131 - INFO - Migrating: /databases/frome/2017/1/2017_1_23.h5
+2017-02-13 21:04:18,570 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:04:20,923 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:04:20,958 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:04:23,635 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:04:25,999 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:04:27,711 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:04:28,567 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:04:30,248 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:04:31,820 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:04:33,324 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 21:04:33,345 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:04:33,435 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:04:35,152 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:04:36,654 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:04:38,738 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:04:39,304 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:04:40,776 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:04:42,305 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:04:43,968 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:04:45,434 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:04:47,567 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:04:49,140 - INFO - Migrating: /databases/frome/2016/8/2016_8_5.h5
+2017-02-13 21:04:49,554 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:04:51,290 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:04:52,802 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:04:54,795 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:04:56,239 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:04:57,590 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:04:58,861 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:05:00,053 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:05:01,408 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:05:02,731 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:05:04,106 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:05:05,411 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:05:07,107 - INFO - Migrating: /databases/frome/2016/9/2016_9_27.h5
+2017-02-13 21:05:07,564 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:05:10,822 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:05:11,062 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:05:13,820 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:05:16,502 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:05:19,079 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:05:21,659 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:05:24,197 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:05:26,821 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:05:29,443 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:05:32,044 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:05:34,658 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:05:37,144 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:05:39,680 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:05:42,349 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:05:45,328 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:05:48,198 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:05:50,828 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:05:53,754 - INFO - Migrating: /databases/frome/2016/8/2016_8_8.h5
+2017-02-13 21:05:54,196 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:05:56,288 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:05:58,292 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:05:59,867 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:06:01,370 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:06:02,863 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:06:04,023 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:06:05,564 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:06:07,005 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:06:08,586 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:06:10,051 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:06:11,482 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:06:13,578 - INFO - Migrating: /databases/frome/2016/6/2016_6_5.h5
+2017-02-13 21:06:13,993 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:06:16,710 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:06:17,320 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:06:19,071 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:06:20,717 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:06:23,288 - INFO - Migrating: /databases/frome/2016/7/2016_7_2.h5
+2017-02-13 21:06:23,704 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:06:25,472 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:06:27,090 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:06:27,893 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:06:29,261 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:06:30,636 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:06:32,047 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:06:33,333 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:06:34,567 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:06:36,114 - INFO - Migrating: /databases/frome/2017/1/2017_1_5.h5
+2017-02-13 21:06:36,529 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:06:38,286 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:06:39,963 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:06:40,954 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:06:43,165 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:06:44,789 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:06:46,341 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:06:47,873 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:06:49,453 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:06:49,752 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:06:50,691 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:06:52,359 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:06:53,989 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:06:55,693 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:06:57,299 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:06:58,859 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:07:00,454 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:07:02,019 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:07:03,651 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:07:05,173 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:07:07,407 - INFO - Migrating: /databases/frome/2016/6/2016_6_27.h5
+2017-02-13 21:07:07,850 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:07:09,530 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:07:11,056 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:07:11,700 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:07:13,428 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:07:15,174 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:07:16,643 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 21:07:17,050 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:07:18,463 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:07:19,791 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:07:21,636 - INFO - Migrating: /databases/frome/2016/11/2016_11_16.h5
+2017-02-13 21:07:22,049 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:07:24,614 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:07:27,239 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:07:29,308 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:07:31,589 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:07:33,904 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:07:36,159 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:07:38,425 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:07:40,657 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:07:43,020 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:07:45,419 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:07:47,656 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:07:49,940 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:07:52,271 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:07:54,513 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:07:56,889 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:07:59,672 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:08:02,227 - INFO - Migrating: /databases/frome/2016/10/2016_10_7.h5
+2017-02-13 21:08:02,641 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:08:04,858 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:08:07,080 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:08:07,908 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:08:09,882 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:08:11,890 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:08:13,988 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:08:16,052 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:08:18,154 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:08:20,104 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:08:22,039 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:08:24,096 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:08:26,167 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:08:28,196 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:08:30,222 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:08:32,198 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:08:34,102 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:08:35,051 - INFO - Migrating: /databases/frome/2016/9/2016_9_15.h5
+2017-02-13 21:08:35,491 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:08:39,372 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:08:39,492 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:08:42,574 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:08:45,160 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:08:47,939 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:08:50,548 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:08:53,278 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:08:56,076 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:08:58,636 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:09:01,343 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:09:03,826 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:09:06,463 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:09:09,045 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:09:11,815 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:09:15,142 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:09:17,994 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:09:20,677 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:09:24,254 - INFO - Migrating: /databases/frome/2016/8/2016_8_29.h5
+2017-02-13 21:09:24,710 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:09:27,450 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:09:30,065 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:09:30,640 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:09:32,924 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:09:35,190 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:09:37,349 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:09:39,601 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:09:41,820 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:09:44,080 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:09:46,337 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:09:48,618 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:09:50,770 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:09:52,981 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:09:55,160 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:09:57,834 - INFO - Migrating: /databases/frome/2017/1/2017_1_13.h5
+2017-02-13 21:09:58,275 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:10:00,841 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:10:02,604 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:10:04,215 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:10:06,224 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:10:07,832 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:10:09,467 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:10:11,008 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:10:12,494 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:10:12,699 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:10:14,213 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:10:15,859 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:10:17,490 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:10:19,131 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:10:20,704 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:10:22,384 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:10:23,939 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:10:25,462 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:10:27,016 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:10:28,602 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:10:30,791 - INFO - Migrating: /databases/frome/2016/9/2016_9_17.h5
+2017-02-13 21:10:31,206 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:10:34,449 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:10:37,700 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:10:40,804 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:10:43,531 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:10:46,420 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:10:49,071 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:10:51,712 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:10:54,455 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:10:57,174 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:10:59,764 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:11:02,460 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 21:11:03,152 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:11:05,951 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:11:09,673 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:11:12,735 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:11:15,572 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:11:18,306 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:11:21,371 - INFO - Migrating: /databases/frome/2016/9/2016_9_12.h5
+2017-02-13 21:11:21,811 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:11:23,949 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:11:26,474 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:11:28,562 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:11:30,532 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:11:32,498 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:11:34,531 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:11:36,428 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:11:38,480 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:11:40,588 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:11:41,657 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:11:43,669 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 21:11:44,444 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:11:46,362 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:11:48,335 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:11:50,327 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:11:52,244 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:11:54,194 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:11:56,779 - INFO - Migrating: /databases/frome/2016/11/2016_11_8.h5
+2017-02-13 21:11:57,193 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:12:00,879 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:12:02,253 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:12:04,992 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:12:07,779 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:12:10,487 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:12:13,072 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:12:15,739 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:12:18,589 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:12:21,259 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:12:23,738 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:12:26,374 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:12:29,103 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:12:31,845 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:12:34,836 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:12:37,782 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:12:39,169 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:12:41,983 - INFO - Migrating: /databases/frome/2016/11/2016_11_14.h5
+2017-02-13 21:12:42,424 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:12:46,287 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:12:49,264 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:12:52,346 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:12:55,295 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:12:58,545 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:13:01,380 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:13:04,274 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:13:07,251 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:13:10,025 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:13:12,691 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:13:15,554 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:13:18,852 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:13:21,775 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:13:24,601 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:13:27,493 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:13:27,838 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:13:30,958 - INFO - Migrating: /databases/frome/2016/10/2016_10_2.h5
+2017-02-13 21:13:31,373 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:13:34,125 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:13:36,847 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:13:38,921 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:13:41,006 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:13:43,068 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:13:45,144 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:13:47,201 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:13:49,291 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:13:51,242 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:13:53,371 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:13:55,493 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:13:57,531 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:13:59,692 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:14:01,626 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:14:03,565 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:14:05,585 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:14:08,285 - INFO - Migrating: /databases/frome/2016/7/2016_7_31.h5
+2017-02-13 21:14:08,728 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:14:11,203 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:14:12,714 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:14:14,520 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:14:16,318 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:14:16,565 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:14:18,150 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:14:19,599 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:14:21,115 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:14:22,698 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:14:24,208 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:14:26,066 - INFO - Migrating: /databases/frome/2016/4/2016_4_21.h5
+2017-02-13 21:14:26,481 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:14:29,409 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:14:31,866 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:14:34,737 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:14:37,185 - INFO - Migrating: /databases/frome/2016/3/2016_3_9.h5
+2017-02-13 21:14:37,660 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:14:38,086 - INFO - Migrating: /databases/frome/2016/12/2016_12_24.h5
+2017-02-13 21:14:38,502 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:14:41,133 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:14:43,541 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:14:45,954 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:14:48,330 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:14:50,748 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:14:53,948 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:14:56,430 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:14:58,846 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:14:59,514 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:15:01,963 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:15:04,399 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:15:06,813 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:15:09,366 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:15:11,804 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:15:14,646 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:15:16,961 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:15:19,478 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:15:21,947 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:15:24,818 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:15:27,638 - INFO - Migrating: /databases/frome/2016/7/2016_7_11.h5
+2017-02-13 21:15:28,086 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:15:30,099 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:15:31,942 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:15:32,497 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:15:34,555 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:15:36,373 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:15:37,969 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:15:39,664 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:15:41,354 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:15:43,384 - INFO - Migrating: /databases/frome/2016/5/2016_5_18.h5
+2017-02-13 21:15:43,799 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:15:45,570 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:15:47,648 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:15:49,386 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:15:51,208 - INFO - Migrating: /databases/frome/2016/9/2016_9_10.h5
+2017-02-13 21:15:51,642 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:15:53,513 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:15:55,284 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:15:57,119 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:15:59,305 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:16:01,072 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:16:02,816 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:16:04,511 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:16:06,246 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:16:07,961 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:16:09,647 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:16:11,456 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:16:13,213 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:16:15,025 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:16:16,744 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:16:18,440 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:16:20,643 - INFO - Migrating: /databases/frome/2016/9/2016_9_19.h5
+2017-02-13 21:16:21,058 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:16:24,821 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:16:24,833 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:16:27,428 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:16:29,675 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:16:31,978 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:16:34,314 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:16:36,470 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:16:38,778 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:16:40,943 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:16:43,106 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:16:45,285 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:16:47,530 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 21:16:48,239 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:16:50,540 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:16:52,923 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:16:55,213 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:16:57,467 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:17:00,257 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:17:02,804 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_91/singles
+2017-02-13 21:17:03,286 - ERROR - No information in HiSPARCNetwork() for sn 91
+2017-02-13 21:17:03,298 - INFO - Migrating: /databases/frome/2016/11/2016_11_7.h5
+2017-02-13 21:17:03,738 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:17:06,805 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:17:07,986 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:17:08,892 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:17:11,898 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:17:14,770 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:17:17,687 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:17:20,413 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:17:23,353 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:17:26,298 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:17:29,014 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:17:31,761 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:17:34,572 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:17:37,359 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:17:40,428 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:17:43,812 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:17:46,659 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:17:47,024 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:17:49,999 - INFO - Migrating: /databases/frome/2016/6/2016_6_6.h5
+2017-02-13 21:17:50,429 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:17:52,209 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:17:52,784 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:17:52,804 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:17:55,015 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:17:56,643 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:17:58,409 - INFO - Migrating: /databases/frome/2016/4/2016_4_8.h5
+2017-02-13 21:17:58,839 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:18:01,835 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:18:03,995 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:18:05,844 - INFO - Migrating: /databases/frome/2016/11/2016_11_4.h5
+2017-02-13 21:18:06,323 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:18:09,987 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:18:13,140 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:18:14,307 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:18:17,376 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:18:20,540 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:18:23,708 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:18:26,693 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:18:29,663 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:18:32,929 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:18:35,880 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:18:38,861 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:18:42,225 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:18:42,236 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:18:45,764 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:18:48,927 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:18:52,101 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:18:55,613 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:18:58,872 - INFO - Migrating: /databases/frome/2016/12/2016_12_9.h5
+2017-02-13 21:18:59,287 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:19:01,673 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:19:02,215 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:19:04,506 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:19:06,159 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:19:07,110 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:19:08,721 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:19:10,354 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:19:11,908 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:19:13,349 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:19:15,020 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:19:16,522 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:19:18,183 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:19:19,780 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:19:20,440 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:19:22,235 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:19:23,827 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:19:25,414 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:19:26,983 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:19:28,570 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:19:31,200 - INFO - Migrating: /databases/frome/2017/1/2017_1_10.h5
+2017-02-13 21:19:31,639 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:19:31,689 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:19:33,524 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:19:35,564 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:19:36,716 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:19:38,509 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:19:40,108 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:19:41,612 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:19:43,103 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:19:44,715 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:19:45,557 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:19:47,061 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:19:48,644 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:19:50,127 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:19:52,554 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:19:54,213 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:19:55,726 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:19:57,331 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:19:58,854 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:20:00,393 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:20:02,582 - INFO - Migrating: /databases/frome/2016/11/2016_11_12.h5
+2017-02-13 21:20:02,997 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:20:06,260 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:20:09,351 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:20:12,284 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:20:15,275 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:20:18,191 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:20:21,065 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:20:24,186 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:20:27,202 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:20:30,064 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:20:32,870 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:20:35,586 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:20:38,841 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:20:41,617 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:20:44,792 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:20:47,819 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:20:48,242 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:20:51,522 - INFO - Migrating: /databases/frome/2016/5/2016_5_22.h5
+2017-02-13 21:20:51,964 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1102/singles
+2017-02-13 21:20:53,662 - ERROR - No information in HiSPARCNetwork() for sn 1102
+2017-02-13 21:20:53,676 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:20:55,740 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:20:57,358 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:20:58,949 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:21:00,752 - INFO - Migrating: /databases/frome/2016/9/2016_9_29.h5
+2017-02-13 21:21:01,167 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:21:04,278 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:21:04,344 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:21:07,269 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:21:10,129 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:21:12,868 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:21:15,730 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:21:18,582 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:21:21,501 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:21:24,271 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:21:27,020 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:21:29,820 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:21:32,588 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 21:21:33,218 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:21:36,097 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:21:39,514 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:21:42,480 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:21:45,293 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:21:48,061 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:21:51,071 - INFO - Migrating: /databases/frome/2016/3/2016_3_30.h5
+2017-02-13 21:21:51,504 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:21:53,317 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:21:55,020 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:21:56,869 - INFO - Migrating: /databases/frome/2016/5/2016_5_5.h5
+2017-02-13 21:21:57,324 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:21:59,062 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:22:00,684 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:22:02,483 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:22:04,043 - INFO - Migrating: /databases/frome/2016/5/2016_5_20.h5
+2017-02-13 21:22:04,465 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1102/singles
+2017-02-13 21:22:06,073 - ERROR - No information in HiSPARCNetwork() for sn 1102
+2017-02-13 21:22:06,091 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:22:07,680 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:22:09,297 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:22:11,088 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:22:12,897 - INFO - Migrating: /databases/frome/2017/1/2017_1_25.h5
+2017-02-13 21:22:13,309 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:22:14,152 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:22:14,171 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:22:15,952 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:22:18,045 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:22:19,752 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:22:21,570 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:22:23,197 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:22:24,763 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:22:26,345 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 21:22:27,079 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:22:28,512 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:22:30,073 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:22:31,684 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:22:33,121 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:22:34,724 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:22:36,276 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:22:37,830 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:22:39,458 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:22:40,993 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:22:43,208 - INFO - Migrating: /databases/frome/2016/3/2016_3_11.h5
+2017-02-13 21:22:43,622 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:22:44,985 - INFO - Migrating: /databases/frome/2016/6/2016_6_8.h5
+2017-02-13 21:22:45,401 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:22:47,342 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:22:47,808 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:22:47,881 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:22:49,678 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:22:50,413 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:22:52,069 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_521/singles
+2017-02-13 21:22:53,640 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_93/singles
+2017-02-13 21:22:54,027 - ERROR - No information in HiSPARCNetwork() for sn 93
+2017-02-13 21:22:54,220 - INFO - Migrating: /databases/frome/2017/1/2017_1_27.h5
+2017-02-13 21:22:54,633 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:22:56,768 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:22:58,428 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:23:00,440 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:23:02,053 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:23:03,701 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:23:05,256 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:23:06,891 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 21:23:08,427 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:23:10,115 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:23:11,667 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:23:13,475 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:23:15,156 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:23:16,918 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:23:18,699 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:23:20,396 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:23:22,137 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:23:22,704 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:23:24,948 - INFO - Migrating: /databases/frome/2016/7/2016_7_5.h5
+2017-02-13 21:23:25,400 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:23:27,702 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:23:29,667 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:23:30,526 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:23:32,231 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:23:33,746 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:23:35,248 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:23:36,736 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:23:38,217 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:23:39,941 - INFO - Migrating: /databases/frome/2016/5/2016_5_2.h5
+2017-02-13 21:23:40,370 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:23:42,651 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:23:44,376 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:23:46,699 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:23:48,529 - INFO - Migrating: /databases/frome/2016/11/2016_11_1.h5
+2017-02-13 21:23:48,945 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:23:50,961 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:23:51,081 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:23:53,219 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:23:54,356 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:23:56,386 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:23:58,296 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:24:00,147 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:24:01,963 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:24:03,758 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:24:03,947 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:24:05,745 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:24:07,572 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:24:09,563 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:24:11,378 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:24:13,189 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:24:15,030 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:24:16,936 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:24:17,336 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:24:19,895 - INFO - Migrating: /databases/frome/2016/3/2016_3_16.h5
+2017-02-13 21:24:20,326 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:24:21,881 - INFO - Migrating: /databases/frome/2016/3/2016_3_13.h5
+2017-02-13 21:24:22,307 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:24:22,939 - INFO - Migrating: /databases/frome/2016/11/2016_11_3.h5
+2017-02-13 21:24:23,370 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:24:25,809 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:24:25,882 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:24:28,928 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:24:30,074 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:24:32,403 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:24:34,670 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:24:36,872 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:24:39,092 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:24:41,285 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:24:43,600 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:24:45,775 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:24:47,974 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:24:50,154 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:24:52,343 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:24:55,155 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:24:57,290 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:24:59,963 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:25:00,482 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:25:02,675 - INFO - Migrating: /databases/frome/2016/11/2016_11_15.h5
+2017-02-13 21:25:03,155 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:25:05,999 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:25:06,084 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:25:09,184 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:25:11,917 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:25:14,612 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:25:17,490 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:25:20,203 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:25:22,844 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:25:25,569 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:25:27,100 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:25:29,762 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:25:32,392 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:25:35,059 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:25:37,612 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:25:41,126 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:25:44,044 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:25:46,658 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:25:46,825 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:25:49,716 - INFO - Migrating: /databases/frome/2016/10/2016_10_6.h5
+2017-02-13 21:25:50,142 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:25:52,808 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:25:52,845 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:25:55,530 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:25:56,246 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:25:58,784 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:26:01,268 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:26:03,776 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:26:06,211 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:26:08,623 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:26:11,170 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:26:13,677 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:26:16,158 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 21:26:16,697 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:26:19,219 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:26:21,739 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:26:24,416 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:26:26,818 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:26:29,129 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:26:30,915 - INFO - Migrating: /databases/frome/2016/6/2016_6_13.h5
+2017-02-13 21:26:31,374 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:26:32,243 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:26:34,103 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:26:34,598 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:26:36,987 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:26:38,717 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:26:40,386 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_521/singles
+2017-02-13 21:26:42,411 - INFO - Migrating: /databases/frome/2016/12/2016_12_13.h5
+2017-02-13 21:26:42,827 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:26:45,010 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:26:46,346 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:26:46,439 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:26:48,489 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:26:50,171 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:26:51,130 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:26:52,962 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:26:54,887 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:26:56,734 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:26:58,025 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:26:59,734 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:27:00,754 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:27:02,602 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:27:04,427 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:27:05,750 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:27:07,584 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:27:09,443 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:27:11,234 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:27:13,015 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:27:14,803 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:27:17,305 - INFO - Migrating: /databases/frome/2017/2/2017_2_10.h5
+2017-02-13 21:27:17,736 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:27:20,259 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:27:22,678 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:27:24,421 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:27:26,011 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:27:27,519 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:27:29,029 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:27:30,555 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:27:32,112 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 21:27:33,769 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:27:35,400 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:27:37,157 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:27:38,803 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:27:40,359 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:27:41,912 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:27:43,518 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:27:45,155 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:27:46,796 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:27:48,942 - INFO - Migrating: /databases/frome/2016/9/2016_9_26.h5
+2017-02-13 21:27:49,404 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:27:53,173 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:27:56,379 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:27:59,170 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:28:02,192 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:28:04,994 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:28:07,746 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:28:10,502 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:28:13,454 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:28:16,124 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:28:18,882 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:28:21,665 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:28:24,795 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:28:27,547 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:28:30,796 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:28:33,819 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:28:36,646 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:28:39,695 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_91/singles
+2017-02-13 21:28:40,862 - ERROR - No information in HiSPARCNetwork() for sn 91
+2017-02-13 21:28:40,991 - INFO - Migrating: /databases/frome/2016/9/2016_9_30.h5
+2017-02-13 21:28:41,417 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:28:44,420 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:28:44,438 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:28:47,281 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:28:50,057 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:28:52,831 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:28:55,845 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:28:58,676 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:29:01,561 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:29:04,382 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:29:07,213 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:29:09,999 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:29:12,683 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_24/singles
+2017-02-13 21:29:13,185 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:29:16,105 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:29:19,388 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:29:22,202 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:29:25,284 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:29:28,158 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:29:31,234 - INFO - Migrating: /databases/frome/2016/9/2016_9_8.h5
+2017-02-13 21:29:31,691 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:29:33,701 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:29:33,741 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:29:35,615 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:29:37,347 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:29:39,522 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:29:41,429 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:29:43,104 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:29:44,862 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:29:46,075 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:29:47,855 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:29:49,642 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:29:51,357 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:29:53,175 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:29:54,986 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:29:56,785 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:29:58,474 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:30:00,816 - INFO - Migrating: /databases/frome/2016/5/2016_5_8.h5
+2017-02-13 21:30:01,231 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:30:03,608 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:30:05,325 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:30:06,940 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:30:08,781 - INFO - Migrating: /databases/frome/2016/6/2016_6_14.h5
+2017-02-13 21:30:09,256 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:30:11,456 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:30:14,027 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:30:14,553 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:30:16,262 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:30:17,723 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:30:18,323 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:30:19,918 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_521/singles
+2017-02-13 21:30:21,041 - INFO - Migrating: /databases/frome/2016/11/2016_11_22.h5
+2017-02-13 21:30:21,457 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:30:23,676 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:30:23,769 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:30:25,964 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:30:27,640 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:30:29,222 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:30:30,857 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:30:32,397 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:30:33,977 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:30:35,707 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:30:37,274 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:30:38,845 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:30:40,433 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:30:40,897 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:30:42,495 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:30:44,289 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:30:45,884 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:30:47,483 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:30:49,648 - INFO - Migrating: /databases/frome/2016/6/2016_6_11.h5
+2017-02-13 21:30:50,112 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:30:53,725 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:30:54,450 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:30:56,979 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:30:59,219 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:31:01,469 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_521/singles
+2017-02-13 21:31:04,025 - INFO - Migrating: /databases/frome/2016/11/2016_11_18.h5
+2017-02-13 21:31:04,457 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:31:06,610 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:31:06,640 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:31:08,959 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:31:11,032 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:31:12,814 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:31:14,703 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:31:16,573 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:31:18,470 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:31:20,478 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:31:22,464 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:31:24,320 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:31:26,251 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:31:28,064 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:31:30,029 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:31:31,953 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:31:33,957 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:31:35,894 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:31:36,077 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:31:38,644 - INFO - Migrating: /databases/frome/2016/12/2016_12_16.h5
+2017-02-13 21:31:39,065 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:31:42,731 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:31:44,316 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:31:47,364 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:31:50,279 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:31:53,220 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:31:56,035 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:31:58,884 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:32:01,619 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:32:02,286 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:32:05,220 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:32:05,591 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:32:08,593 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:32:11,546 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:32:14,823 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:32:17,981 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:32:20,916 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:32:23,834 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:32:26,575 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:32:29,461 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:32:32,345 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:32:33,097 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:32:36,025 - INFO - Migrating: /databases/frome/2016/6/2016_6_30.h5
+2017-02-13 21:32:36,485 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:32:38,125 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:32:39,628 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:32:40,557 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:32:41,932 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:32:43,385 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:32:44,772 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:32:46,190 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:32:47,547 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:32:49,232 - INFO - Migrating: /databases/frome/2016/11/2016_11_30.h5
+2017-02-13 21:32:49,656 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:32:51,485 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:32:53,361 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:32:54,589 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:32:56,320 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:32:57,924 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:32:59,609 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:33:01,259 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:33:02,872 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:33:04,528 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:33:06,163 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:33:07,815 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:33:09,523 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:33:11,178 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:33:12,815 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:33:14,562 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:33:16,241 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:33:17,830 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:33:20,316 - INFO - Migrating: /databases/frome/2016/4/2016_4_4.h5
+2017-02-13 21:33:20,749 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:33:23,486 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:33:25,923 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:33:27,639 - INFO - Migrating: /databases/frome/2016/3/2016_3_18.h5
+2017-02-13 21:33:28,053 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:33:29,117 - INFO - Migrating: /databases/frome/2017/1/2017_1_21.h5
+2017-02-13 21:33:29,556 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:33:31,361 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:33:33,533 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:33:35,191 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:33:36,819 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:33:38,527 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:33:40,395 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:33:42,023 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:33:42,561 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:33:44,201 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:33:45,817 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:33:47,464 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:33:48,075 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:33:49,684 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:33:51,397 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:33:53,340 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:33:54,946 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:33:56,525 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:33:58,783 - INFO - Migrating: /databases/frome/2016/12/2016_12_21.h5
+2017-02-13 21:33:59,238 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:34:03,434 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:34:06,498 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:34:09,434 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:34:12,385 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:34:15,219 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:34:18,054 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:34:21,336 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:34:24,269 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:34:24,944 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:34:27,885 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:34:28,212 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:34:31,156 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:34:34,053 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:34:36,932 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:34:40,283 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:34:42,389 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:34:45,377 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:34:48,461 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:34:51,476 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:34:54,488 - INFO - Migrating: /databases/frome/2016/12/2016_12_31.h5
+2017-02-13 21:34:54,900 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:34:56,600 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:34:58,171 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:35:00,207 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:35:01,865 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:35:03,374 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:35:04,927 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:35:06,361 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:35:07,927 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:35:08,478 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:35:10,145 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:35:11,830 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:35:13,379 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:35:14,808 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:35:16,312 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:35:17,767 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:35:19,282 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:35:21,099 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:35:23,156 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:35:24,749 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:35:27,189 - INFO - Migrating: /databases/frome/2016/7/2016_7_8.h5
+2017-02-13 21:35:27,649 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:35:29,395 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:35:31,067 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:35:31,703 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:35:33,255 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:35:35,581 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:35:37,108 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:35:38,534 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:35:39,979 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:35:41,674 - INFO - Migrating: /databases/frome/2016/7/2016_7_26.h5
+2017-02-13 21:35:42,103 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:35:44,320 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:35:46,629 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:35:48,215 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:35:49,862 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:35:51,015 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:35:52,718 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:35:54,380 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:35:55,919 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:35:57,525 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:35:59,470 - INFO - Migrating: /databases/frome/2016/11/2016_11_19.h5
+2017-02-13 21:35:59,883 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:36:03,648 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:36:05,543 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:36:07,210 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:36:08,857 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:36:10,497 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:36:12,058 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:36:13,667 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:36:15,368 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:36:16,987 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:36:18,539 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:36:20,322 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:36:22,183 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:36:23,824 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:36:25,479 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:36:27,084 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:36:28,736 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:36:30,896 - INFO - Migrating: /databases/frome/2016/3/2016_3_14.h5
+2017-02-13 21:36:31,337 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:36:33,163 - INFO - Migrating: /databases/frome/2016/8/2016_8_22.h5
+2017-02-13 21:36:33,593 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:36:35,706 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:36:38,207 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:36:39,548 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:36:41,402 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:36:43,234 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:36:45,076 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:36:46,898 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:36:48,595 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:36:50,393 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:36:52,071 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:36:54,021 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:36:55,758 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:36:57,530 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:36:59,214 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:37:01,382 - INFO - Migrating: /databases/frome/2016/4/2016_4_28.h5
+2017-02-13 21:37:01,815 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:37:04,878 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:37:07,306 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:37:10,108 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:37:12,596 - INFO - Migrating: /databases/frome/2016/9/2016_9_7.h5
+2017-02-13 21:37:13,008 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:37:15,347 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:37:17,800 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:37:19,451 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:37:21,883 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:37:24,006 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:37:26,160 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:37:28,264 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:37:28,970 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:37:31,023 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:37:33,101 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:37:35,223 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:37:37,186 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:37:39,415 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:37:41,467 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:37:43,577 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:37:46,183 - INFO - Migrating: /databases/frome/2016/11/2016_11_6.h5
+2017-02-13 21:37:46,631 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:37:50,561 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:37:53,964 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:37:55,300 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:37:58,559 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:38:01,625 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:38:04,600 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:38:07,488 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:38:10,455 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:38:13,689 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:38:16,642 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:38:19,619 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:38:22,827 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:38:26,292 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:38:29,524 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:38:32,749 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:38:35,924 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:38:39,119 - INFO - Migrating: /databases/frome/2016/3/2016_3_12.h5
+2017-02-13 21:38:39,541 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:38:41,970 - INFO - Migrating: /databases/frome/2016/8/2016_8_15.h5
+2017-02-13 21:38:42,402 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:38:44,645 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:38:47,048 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:38:48,983 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:38:50,949 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:38:52,782 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:38:54,937 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:38:56,848 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:38:58,229 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:39:00,097 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:39:01,872 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:39:03,785 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:39:05,650 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:39:07,421 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:39:09,726 - INFO - Migrating: /databases/frome/2016/12/2016_12_11.h5
+2017-02-13 21:39:10,176 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:39:12,639 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:39:14,769 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:39:16,627 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:39:18,464 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:39:19,352 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:39:21,154 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:39:23,188 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:39:24,826 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:39:26,588 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:39:28,246 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:39:29,210 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:39:30,959 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:39:32,638 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:39:33,309 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:39:34,995 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:39:36,697 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:39:38,313 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:39:39,852 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:39:41,541 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:39:43,952 - INFO - Migrating: /databases/frome/2016/3/2016_3_25.h5
+2017-02-13 21:39:44,367 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:39:44,978 - INFO - Migrating: /databases/frome/2016/8/2016_8_25.h5
+2017-02-13 21:39:45,418 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:39:48,522 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:39:51,677 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:39:54,733 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:39:55,432 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:39:58,206 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:40:00,176 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:40:02,782 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:40:05,324 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:40:07,894 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:40:10,623 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:40:13,226 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:40:15,714 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:40:18,411 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:40:21,123 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:40:24,387 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:40:27,282 - INFO - Migrating: /databases/frome/2016/8/2016_8_17.h5
+2017-02-13 21:40:27,735 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:40:30,964 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:40:33,833 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:40:36,562 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:40:39,127 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:40:41,676 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:40:44,447 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:40:47,188 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:40:49,943 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:40:52,650 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:40:55,312 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:40:57,732 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:41:00,373 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:41:03,383 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:41:06,199 - INFO - Migrating: /databases/frome/2016/8/2016_8_20.h5
+2017-02-13 21:41:06,628 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:41:08,482 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:41:10,543 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:41:12,656 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:41:14,321 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:41:15,837 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:41:17,407 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:41:19,065 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:41:20,643 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:41:22,391 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:41:24,071 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:41:25,751 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:41:27,376 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:41:28,939 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:41:31,022 - INFO - Migrating: /databases/frome/2016/5/2016_5_27.h5
+2017-02-13 21:41:31,477 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:41:34,231 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:41:34,455 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:41:37,163 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:41:38,970 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:41:40,923 - INFO - Migrating: /databases/frome/2016/12/2016_12_26.h5
+2017-02-13 21:41:41,412 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:41:43,892 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:41:46,226 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:41:48,639 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:41:51,001 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:41:53,379 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:41:55,849 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:41:58,204 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:42:00,502 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:42:01,180 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:42:03,513 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:42:05,714 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:42:07,992 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:42:10,283 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:42:12,584 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:42:14,845 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:42:17,244 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:42:20,228 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:42:22,822 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:42:25,334 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:42:27,688 - INFO - Migrating: /databases/frome/2016/11/2016_11_20.h5
+2017-02-13 21:42:28,131 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:42:29,894 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:42:31,897 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:42:33,600 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:42:35,276 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:42:36,871 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:42:38,469 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:42:40,215 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:42:41,915 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:42:43,482 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:42:45,056 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:42:46,684 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:42:48,279 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:42:49,978 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:42:51,633 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:42:53,200 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:42:54,693 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:42:57,000 - INFO - Migrating: /databases/frome/2016/11/2016_11_29.h5
+2017-02-13 21:42:57,458 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:43:00,012 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:43:00,183 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:43:02,338 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:43:03,562 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:43:05,402 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:43:07,179 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:43:08,762 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:43:10,424 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:43:12,058 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:43:13,929 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:43:15,574 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:43:17,359 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:43:19,051 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:43:20,901 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:43:20,913 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:43:22,798 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:43:24,386 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:43:26,064 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:43:27,714 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:43:30,310 - INFO - Migrating: /databases/frome/2016/6/2016_6_16.h5
+2017-02-13 21:43:30,754 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:43:32,610 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:43:34,674 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:43:36,586 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:43:38,273 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:43:39,414 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:43:40,994 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:43:42,589 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:43:44,063 - INFO - Migrating: /databases/frome/2016/7/2016_7_22.h5
+2017-02-13 21:43:44,493 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:43:46,539 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:43:48,474 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:43:50,435 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:43:52,236 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:43:54,547 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:43:56,416 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:43:58,272 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:44:00,110 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:44:01,937 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:44:03,798 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:44:06,083 - INFO - Migrating: /databases/frome/2016/4/2016_4_5.h5
+2017-02-13 21:44:06,533 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:44:09,452 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:44:11,614 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:44:13,285 - INFO - Migrating: /databases/frome/2017/1/2017_1_11.h5
+2017-02-13 21:44:13,713 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:44:15,782 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:44:17,712 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:44:19,410 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:44:21,244 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:44:23,191 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:44:24,720 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:44:26,352 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:44:27,985 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:44:28,956 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:44:30,578 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:44:32,232 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:44:33,812 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:44:35,386 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:44:36,948 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:44:38,516 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:44:40,094 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:44:41,647 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:44:43,248 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:44:45,452 - INFO - Migrating: /databases/frome/2016/6/2016_6_10.h5
+2017-02-13 21:44:45,883 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:44:48,933 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:44:49,435 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:44:52,040 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:44:52,201 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:44:54,347 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:44:56,521 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_521/singles
+2017-02-13 21:44:58,831 - INFO - Migrating: /databases/frome/2016/5/2016_5_11.h5
+2017-02-13 21:44:59,245 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:44:59,889 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:45:01,662 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:45:03,860 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:45:05,689 - INFO - Migrating: /databases/frome/2017/1/2017_1_28.h5
+2017-02-13 21:45:06,128 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:45:08,327 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:45:10,333 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:45:11,917 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:45:13,519 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:45:15,114 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:45:16,730 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:45:18,318 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 21:45:20,040 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:45:21,671 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:45:23,485 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:45:24,968 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:45:26,552 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:45:28,132 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:45:29,701 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:45:31,203 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:45:32,820 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:45:34,944 - INFO - Migrating: /databases/frome/2016/5/2016_5_4.h5
+2017-02-13 21:45:35,382 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:45:38,226 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:45:40,668 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:45:42,342 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:45:44,311 - INFO - Migrating: /databases/frome/2016/10/2016_10_19.h5
+2017-02-13 21:45:44,785 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:45:46,689 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:45:48,501 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:45:49,485 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:45:51,605 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:45:53,596 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:45:55,284 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:45:56,975 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:45:58,673 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:46:00,275 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:46:01,973 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:46:03,724 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:46:05,359 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:46:07,096 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:46:08,752 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:46:10,489 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:46:12,113 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_508/singles
+2017-02-13 21:46:12,719 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:46:14,983 - INFO - Migrating: /databases/frome/2016/7/2016_7_7.h5
+2017-02-13 21:46:15,415 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:46:17,645 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:46:19,293 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:46:20,028 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:46:22,326 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:46:24,066 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:46:25,572 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:46:27,007 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:46:28,389 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:46:30,105 - INFO - Migrating: /databases/frome/2016/7/2016_7_4.h5
+2017-02-13 21:46:30,537 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:46:32,522 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:46:34,337 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:46:35,381 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:46:41,778 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:46:48,691 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:46:54,459 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:46:59,055 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:47:05,927 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:47:11,861 - INFO - Migrating: /databases/frome/2017/1/2017_1_26.h5
+2017-02-13 21:47:13,197 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:47:13,240 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:47:18,776 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:47:24,554 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:47:30,134 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:47:35,628 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:47:40,060 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:47:45,084 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:47:52,801 - INFO - Migrating table: /hisparc/cluster_bristol/station_13005/singles
+2017-02-13 21:47:57,814 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:48:03,013 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:48:07,898 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:48:12,816 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:48:18,957 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:48:26,354 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:48:32,211 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:48:37,875 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:48:43,522 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:48:48,029 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:48:53,536 - INFO - Migrating: /databases/frome/2016/7/2016_7_27.h5
+2017-02-13 21:48:55,007 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:49:00,936 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:49:06,874 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:49:13,232 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:49:19,465 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:49:22,880 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:49:29,026 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:49:35,467 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:49:41,607 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:49:47,932 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:49:54,530 - INFO - Migrating: /databases/frome/2017/1/2017_1_24.h5
+2017-02-13 21:49:56,159 - INFO - Migrating table: /hisparc/cluster_sussex/station_15001/singles
+2017-02-13 21:50:02,449 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:50:10,218 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:50:16,174 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:50:22,293 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:50:29,141 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:50:34,289 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:50:39,185 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:50:43,596 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:50:47,931 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:50:52,801 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:50:58,863 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:51:01,103 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:51:07,069 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:51:12,694 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:51:18,756 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:51:25,168 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:51:31,472 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:51:38,566 - INFO - Migrating: /databases/frome/2016/7/2016_7_9.h5
+2017-02-13 21:51:40,471 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:51:48,191 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:51:55,098 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:51:56,194 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:52:00,862 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:52:05,285 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:52:10,028 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:52:14,149 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:52:18,393 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:52:23,608 - INFO - Migrating: /databases/frome/2016/12/2016_12_30.h5
+2017-02-13 21:52:24,856 - INFO - Migrating table: /hisparc/cluster_leiden/station_3105/singles
+2017-02-13 21:52:28,884 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:52:33,848 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:52:37,853 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:52:42,241 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:52:46,585 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:52:51,703 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:52:56,061 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:53:01,898 - INFO - Migrating table: /hisparc/cluster_bristol/station_13601/singles
+2017-02-13 21:53:05,041 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:53:11,901 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_203/singles
+2017-02-13 21:53:17,969 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:53:24,334 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:53:30,304 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:53:36,738 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_303/singles
+2017-02-13 21:53:43,965 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:53:51,176 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:53:55,868 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:54:03,066 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:54:10,732 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:54:19,080 - INFO - Migrating: /databases/frome/2016/9/2016_9_1.h5
+2017-02-13 21:54:21,074 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:54:27,942 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:54:34,220 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:54:36,670 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:54:41,926 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:54:47,098 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:54:52,350 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:54:58,092 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:55:04,894 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:55:10,329 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:55:17,019 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:55:23,034 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:55:28,194 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:55:33,644 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:55:38,813 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:55:44,302 - INFO - Migrating: /databases/frome/2016/10/2016_10_22.h5
+2017-02-13 21:55:46,084 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:55:50,722 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:55:56,086 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:55:59,526 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:56:04,773 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:56:09,703 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:56:14,540 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:56:19,877 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:56:25,368 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:56:31,666 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:56:37,551 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:56:43,856 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:56:50,063 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 21:56:56,002 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:57:02,607 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:57:09,199 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:57:15,378 - INFO - Migrating: /databases/frome/2016/7/2016_7_19.h5
+2017-02-13 21:57:16,943 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:57:24,057 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:57:24,390 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:57:30,935 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:57:36,826 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:57:42,867 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:57:49,186 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:57:54,775 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:58:00,810 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:58:07,492 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:58:13,667 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:58:19,745 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 21:58:26,295 - INFO - Migrating: /databases/frome/2016/5/2016_5_28.h5
+2017-02-13 21:58:27,875 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:58:34,430 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:58:39,322 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 21:58:44,843 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 21:58:50,759 - INFO - Migrating: /databases/frome/2016/10/2016_10_20.h5
+2017-02-13 21:58:51,999 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 21:58:57,138 - INFO - Migrating table: /hisparc/cluster_nijmegen/station_2101/singles
+2017-02-13 21:58:57,347 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 21:59:02,242 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 21:59:05,936 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 21:59:11,308 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 21:59:16,543 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 21:59:21,797 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 21:59:27,022 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 21:59:32,396 - INFO - Migrating table: /hisparc/cluster_birmingham/station_14004/singles
+2017-02-13 21:59:38,373 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 21:59:43,010 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 21:59:47,637 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 21:59:52,367 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 21:59:56,740 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 22:00:00,945 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 22:00:05,901 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 22:00:11,878 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 22:00:17,537 - INFO - Migrating: /databases/frome/2016/4/2016_4_30.h5
+2017-02-13 22:00:19,137 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 22:00:25,125 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_21/singles
+2017-02-13 22:00:30,433 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 22:00:35,586 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 22:00:40,940 - INFO - Migrating: /databases/frome/2016/9/2016_9_3.h5
+2017-02-13 22:00:42,047 - INFO - Migrating table: /hisparc/cluster_utrecht/station_1101/singles
+2017-02-13 22:00:47,313 - INFO - Migrating table: /hisparc/cluster_leiden/station_3501/singles
+2017-02-13 22:00:52,784 - INFO - Migrating table: /hisparc/cluster_leiden/station_3701/singles
+2017-02-13 22:00:55,348 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8001/singles
+2017-02-13 22:01:01,334 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8004/singles
+2017-02-13 22:01:06,969 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8008/singles
+2017-02-13 22:01:12,485 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8009/singles
+2017-02-13 22:01:18,734 - INFO - Migrating table: /hisparc/cluster_eindhoven/station_8101/singles
+2017-02-13 22:01:25,341 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_23/singles
+2017-02-13 22:01:30,671 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_301/singles
+2017-02-13 22:01:35,800 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_304/singles
+2017-02-13 22:01:41,480 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_305/singles
+2017-02-13 22:01:47,062 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_501/singles
+2017-02-13 22:01:52,002 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 22:01:57,782 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_510/singles
+2017-02-13 22:02:03,282 - INFO - Migrating: /databases/frome/2016/3/2016_3_17.h5
+2017-02-13 22:02:04,746 - INFO - Migrating table: /hisparc/cluster_amsterdam/station_507/singles
+2017-02-13 22:02:08,448 - INFO - Searching for unmigrated singles tables
+2017-02-13 22:37:14,007 - INFO - Found 0 unmigrated tables in 0 datastore files.
+2017-02-13 22:37:14,008 - INFO - ********************
+2017-02-13 22:37:14,008 - INFO - Migration succesful!
+2017-02-13 22:37:14,008 - INFO - ********************
+2017-02-13 22:37:14,008 - INFO - Done.

--- a/scripts/send_fake_events.py
+++ b/scripts/send_fake_events.py
@@ -1,0 +1,26 @@
+import datetime
+import random
+import time
+
+import numpy as np
+
+import pysparc.events
+import pysparc.storage
+
+
+class FakeMessage(object):
+
+    datetime = datetime.datetime.now()
+    timestamp = time.time()
+    nanoseconds = int(random.uniform(0, 1e9))
+    ext_timestamp = int(timestamp) * int(1e9) + nanoseconds
+    trigger_pattern = 1
+    trace_ch1 = np.arange(10)
+    trace_ch2 = np.arange(10)
+
+
+datastore = pysparc.storage.NikhefDataStore(99, 'fake_station',
+                                            url='http://localhost:8083')
+for i in range(100):
+    event = pysparc.events.Event(FakeMessage())
+    datastore.store_event(event)

--- a/writer/storage.py
+++ b/writer/storage.py
@@ -279,7 +279,7 @@ def open_or_create_file(data_dir, date):
         # create dir and parent dirs with mode rwxr-xr-x
         os.makedirs(dir, 0755)
 
-    return tables.openFile(file, 'a')
+    return tables.open_file(file, 'a')
 
 
 def get_or_create_station_group(file, cluster, station_id):
@@ -293,10 +293,10 @@ def get_or_create_station_group(file, cluster, station_id):
     cluster = get_or_create_cluster_group(file, cluster)
     node_name = 'station_%d' % station_id
     try:
-        station = file.getNode(cluster, node_name)
+        station = file.get_node(cluster, node_name)
     except tables.NoSuchNodeError:
-        station = file.createGroup(cluster, node_name,
-                                   'HiSPARC station %d data' % station_id)
+        station = file.create_group(cluster, node_name,
+                                    'HiSPARC station %d data' % station_id)
         file.flush()
 
     return station
@@ -310,17 +310,17 @@ def get_or_create_cluster_group(file, cluster):
 
     """
     try:
-        hisparc = file.getNode('/', 'hisparc')
+        hisparc = file.get_node('/', 'hisparc')
     except tables.NoSuchNodeError:
-        hisparc = file.createGroup('/', 'hisparc', 'HiSPARC data')
+        hisparc = file.create_group('/', 'hisparc', 'HiSPARC data')
         file.flush()
 
     node_name = 'cluster_' + cluster.lower()
     try:
-        cluster = file.getNode(hisparc, node_name)
+        cluster = file.get_node(hisparc, node_name)
     except tables.NoSuchNodeError:
-        cluster = file.createGroup(hisparc, node_name,
-                                   'HiSPARC cluster %s data' % cluster)
+        cluster = file.create_group(hisparc, node_name,
+                                    'HiSPARC cluster %s data' % cluster)
         file.flush()
 
     return cluster
@@ -335,56 +335,58 @@ def get_or_create_node(file, cluster, node):
 
     """
     try:
-        node = file.getNode(cluster, node)
+        node = file.get_node(cluster, node)
     except tables.NoSuchNodeError:
         if node == 'events':
-            node = file.createTable(cluster, 'events', HisparcEvent,
-                                    'HiSPARC event data')
+            node = file.create_table(cluster, 'events', HisparcEvent,
+                                     'HiSPARC event data')
         elif node == 'errors':
-            node = file.createTable(cluster, 'errors', HisparcError,
-                                    'HiSPARC error messages')
+            node = file.create_table(cluster, 'errors', HisparcError,
+                                     'HiSPARC error messages')
         elif node == 'config':
-            node = file.createTable(cluster, 'config', HisparcConfiguration,
-                                    'HiSPARC configuration messages')
+            node = file.create_table(cluster, 'config', HisparcConfiguration,
+                                     'HiSPARC configuration messages')
         elif node == 'comparator':
-            node = file.createTable(cluster, 'comparator', HisparcComparator,
-                                    'HiSPARC comparator messages')
+            node = file.create_table(cluster, 'comparator', HisparcComparator,
+                                     'HiSPARC comparator messages')
         elif node == 'singles':
-            node = file.createTable(cluster, 'singles', HisparcSingle,
-                                    'HiSPARC single messages')
+            node = file.create_table(cluster, 'singles', HisparcSingle,
+                                     'HiSPARC single messages')
         elif node == 'satellites':
-            node = file.createTable(cluster, 'satellites', HisparcSatellite,
-                                    'HiSPARC satellite messages')
+            node = file.create_table(cluster, 'satellites', HisparcSatellite,
+                                     'HiSPARC satellite messages')
         elif node == 'blobs':
-            node = file.createVLArray(cluster, 'blobs', tables.VLStringAtom(),
-                                      'HiSPARC binary data')
+            node = file.create_vlarray(cluster, 'blobs', tables.VLStringAtom(),
+                                       'HiSPARC binary data')
         elif node == 'weather':
-            node = file.createTable(cluster, 'weather', WeatherEvent,
-                                    'HiSPARC weather data')
+            node = file.create_table(cluster, 'weather', WeatherEvent,
+                                     'HiSPARC weather data')
         elif node == 'weather_errors':
-            node = file.createTable(cluster, 'weather_errors', WeatherError,
-                                    'HiSPARC weather error messages')
+            node = file.create_table(cluster, 'weather_errors', WeatherError,
+                                     'HiSPARC weather error messages')
         elif node == 'weather_config':
-            node = file.createTable(cluster, 'weather_config', WeatherConfig,
-                                    'HiSPARC weather configuration messages')
+            node = file.create_table(cluster, 'weather_config', WeatherConfig,
+                                     'HiSPARC weather configuration messages')
         elif node == 'lightning':
-            node = file.createTable(cluster, 'lightning', LightningEvent,
-                                    'HiSPARC lightning data')
+            node = file.create_table(cluster, 'lightning', LightningEvent,
+                                     'HiSPARC lightning data')
         elif node == 'lightning_errors':
-            node = file.createTable(cluster, 'lightning_errors',
-                                    LightningError,
-                                    'HiSPARC lightning error messages')
+            node = file.create_table(cluster, 'lightning_errors',
+                                     LightningError,
+                                     'HiSPARC lightning error messages')
         elif node == 'lightning_config':
-            node = file.createTable(cluster, 'lightning_config',
-                                    LightningConfig,
-                                    'HiSPARC lightning configuration messages')
+            node = file.create_table(cluster, 'lightning_config',
+                                     LightningConfig,
+                                     'HiSPARC lightning configuration '
+                                     'messages')
         elif node == 'lightning_status':
-            node = file.createTable(cluster, 'lightning_status',
-                                    LightningStatus,
-                                    'HiSPARC lightning status messages')
+            node = file.create_table(cluster, 'lightning_status',
+                                     LightningStatus,
+                                     'HiSPARC lightning status messages')
         elif node == 'lightning_noise':
-            node = file.createTable(cluster, 'lightning_noise', LightningNoise,
-                                    'HiSPARC lightning noise messages')
+            node = file.create_table(cluster, 'lightning_noise',
+                                     LightningNoise,
+                                     'HiSPARC lightning noise messages')
         file.flush()
 
     return node

--- a/writer/storage.py
+++ b/writer/storage.py
@@ -131,14 +131,14 @@ class HisparcComparator(tables.IsDescription):
 class HisparcSingle(tables.IsDescription):
     event_id = tables.UInt32Col(pos=0)
     timestamp = tables.Time32Col(pos=1)
-    mas_ch1_low = tables.UInt16Col(pos=2)
-    mas_ch1_high = tables.UInt16Col(pos=3)
-    mas_ch2_low = tables.UInt16Col(pos=4)
-    mas_ch2_high = tables.UInt16Col(pos=5)
-    slv_ch1_low = tables.UInt16Col(pos=6)
-    slv_ch1_high = tables.UInt16Col(pos=7)
-    slv_ch2_low = tables.UInt16Col(pos=8)
-    slv_ch2_high = tables.UInt16Col(pos=9)
+    mas_ch1_low = tables.Int32Col(dflt=-1, pos=2)
+    mas_ch1_high = tables.Int32Col(dflt=-1, pos=3)
+    mas_ch2_low = tables.Int32Col(dflt=-1, pos=4)
+    mas_ch2_high = tables.Int32Col(dflt=-1, pos=5)
+    slv_ch1_low = tables.Int32Col(dflt=-1, pos=6)
+    slv_ch1_high = tables.Int32Col(dflt=-1, pos=7)
+    slv_ch2_low = tables.Int32Col(dflt=-1, pos=8)
+    slv_ch2_high = tables.Int32Col(dflt=-1, pos=9)
 
 
 class HisparcSatellite(tables.IsDescription):

--- a/writer/store_events.py
+++ b/writer/store_events.py
@@ -130,9 +130,9 @@ def store_event_list(data_dir, station_id, cluster, event_list):
             else:
                 logger.error("Strange event (no timestamp!), discarding event "
                              "(station: %s)" % station_id)
-        except:
-            logger.error("Cannot process event, discarding event (station: %s)"
-                         % station_id)
+        except Exception as inst:
+            logger.error("Cannot process event, discarding event (station: "
+                         "%s), exception: %s" % (station_id, inst))
 
     if datafile:
         datafile.close()


### PR DESCRIPTION
Some changes needed for automatically provisioning the datastore (and verifying in a VM that it works).

NOTE: this commit changes openFile to open_file etc. There is a problem with that. The PyTables version currently running on Frome does not yet recognize the new naming scheme. The new version installed when provisioning the VM does not recognize the old naming scheme anymore. So…

Please merge when you are about to sunset old Frome.