### PR TITLE
GPS WNRO: Mark events from Apr 7, 2019 as suspicious.

### DIFF
--- a/scripts/send_fake_events.py
+++ b/scripts/send_fake_events.py
@@ -1,26 +1,29 @@
 import datetime
 import random
-import time
 
 import numpy as np
 
 import pysparc.events
 import pysparc.storage
 
+from sapphire import datetime_to_gps
+
 
 class FakeMessage(object):
 
-    datetime = datetime.datetime.now()
-    timestamp = time.time()
-    nanoseconds = int(random.uniform(0, 1e9))
-    ext_timestamp = int(timestamp) * int(1e9) + nanoseconds
-    trigger_pattern = 1
-    trace_ch1 = np.arange(10)
-    trace_ch2 = np.arange(10)
+    def __init__(self, dt=datetime.datetime.now()):
+        self.datetime = dt
+        self.timestamp = datetime_to_gps(dt)
+        self.nanoseconds = int(random.uniform(0, 1e9))
+        self.ext_timestamp = int(self.timestamp) * int(1e9) + self.nanoseconds
+        self.trigger_pattern = 1
+        self.trace_ch1 = np.arange(10)
+        self.trace_ch2 = np.arange(10)
 
 
-datastore = pysparc.storage.NikhefDataStore(99, 'fake_station',
-                                            url='http://localhost:8083')
-for i in range(100):
-    event = pysparc.events.Event(FakeMessage())
+VM = 'http://localhost:8083/nikhef/upload'
+datastore = pysparc.storage.NikhefDataStore(99, 'fake_station', url=VM)
+
+for d in range(1, 10):
+    event = pysparc.events.Event(FakeMessage(dt=datetime.datetime(2019, 4, d)))
     datastore.store_event(event)

--- a/wsgi/wsgi_app.py
+++ b/wsgi/wsgi_app.py
@@ -1,5 +1,6 @@
 import configparser
 import csv
+import datetime
 import hashlib
 import logging
 import logging.handlers
@@ -154,7 +155,7 @@ def store_data(station_id, cluster, event_list):
     tmp_dir = os.path.join(config.get('General', 'data_dir'), 'tmp')
 
     if is_data_suspicious(event_list):
-        logger.debug('Date < 2013: event list marked as suspicious.')
+        logger.debug('Event list marked as suspicious.')
         dir = os.path.join(config.get('General', 'data_dir'), 'suspicious')
 
     file = tempfile.NamedTemporaryFile(dir=tmp_dir, delete=False)
@@ -174,9 +175,18 @@ def is_data_suspicious(event_list):
     the actual birth of the universe and the reweaving of past fates into
     current events has come to hunt us and our beloved data.
 
+    Apr 7, 2019 0:00 is the default time after a cold start without GPS signal.
+    The DAQ will happily send events even when no GPS signal has been
+    acquired (yet). Events with timestamp Apr 7, 2019 are most probably caused
+    by no or bad GPS signal. Such events must be eigenstates of suspiciousness.
+
     """
     for event in event_list:
         if event['header']['datetime'].year < 2013:
+            logger.debug('Date < 2013: Timestamp has high suspiciousness.')
+            return True
+        if event['header']['datetime'].date() == datetime.date(2019, 4, 7):
+            logger.debug('Date == Apr 7, 2019: No GPS signal?')
             return True
     return False
 


### PR DESCRIPTION
Apr 7, 2019 is the second `GPS WNRO` (week number rollover).
On this day the 10-bit GPS week number overflowed from 1023 back to 0.
GPS week 0 started on Jan 6, 1980. This was the second rollover.
The GPS weeknumber of Apr 7, 2019 is 2048.

Our Trimble Resolution T GPS clocks use the start of weeknumber 2048
(Apr 7, 2019 0:00) as the default time after a GPS cold start (no signal
acquired). As the DAQ will hapilly send events to the datastore even
when no GPS signal has been acquired, we must mark events from Apr 7, 2019
as suspicious and not imported them into the raw datastore.

Fixes #31